### PR TITLE
docs: English translations (i18n EN)

### DIFF
--- a/site/i18n/en/docusaurus-plugin-content-docs/current/admin/apps.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/admin/apps.md
@@ -1,0 +1,73 @@
+# Apps (Catalog)
+
+Fyso allows publishing a tenant as an installable app. Other users can install a copy of the app in their own tenant.
+
+## Flow
+
+1. Design the app (entities, fields, rules) in a tenant
+2. Publish with `publish_app` -- exports the metadata and registers it in the catalog
+3. Share the installation link
+4. Other users install the app -- the metadata is imported into their tenant
+
+## MCP Tool: `publish_app`
+
+**Profile:** core
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Display name (e.g., "CRM Taller Pro") |
+| `slug` | string | Yes | URL identifier (e.g., `"crm-taller-pro"`). Only lowercase letters, numbers, and hyphens |
+| `description` | string | No | Short description |
+| `icon` | string | No | Emoji or icon identifier |
+
+### Example
+
+```
+publish_app({
+  name: "Sistema de Turnos",
+  slug: "sistema-turnos",
+  description: "Gestion de turnos para profesionales de salud",
+  icon: "calendar"
+})
+```
+
+## MCP Tool: `update_app`
+
+**Profile:** core
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `slug` | string | Yes | App slug |
+| `name` | string | No | New name |
+| `description` | string | No | New description |
+| `icon` | string | No | New icon |
+| `refreshMetadata` | boolean | No | Re-export metadata from the current tenant to the app |
+
+Use `refreshMetadata: true` after modifying entities or rules to update the published app.
+
+```
+update_app({
+  slug: "sistema-turnos",
+  refreshMetadata: true
+})
+```
+
+## MCP Tool: `unpublish_app`
+
+**Profile:** core
+
+Deactivates the app from the catalog. This is a soft delete -- it can be published again later.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `slug` | string | Yes | App slug |
+
+```
+unpublish_app({ slug: "sistema-turnos" })
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/admin/import-export.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/admin/import-export.md
@@ -1,0 +1,75 @@
+# Import / Export Metadata
+
+Export and import the structure (entities, fields, rules) of a tenant.
+
+## MCP Tool: `export_metadata`
+
+**Profile:** core
+
+Exports the metadata of the current tenant to a JSON.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tenantId` | string | No | Tenant ID or slug. Default: selected tenant |
+
+### Example
+
+```
+export_metadata()
+```
+
+### Response
+
+Returns a JSON with the complete structure:
+
+```json
+{
+  "entities": [
+    {
+      "name": "clientes",
+      "displayName": "Clientes",
+      "fields": [...],
+      "rules": [...]
+    }
+  ],
+  "version": "1.0",
+  "exportedAt": "2026-02-18T10:00:00Z"
+}
+```
+
+## MCP Tool: `import_metadata`
+
+**Profile:** core
+
+Imports metadata from a JSON into a tenant.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `metadata` | string | Yes | JSON string with the metadata to import |
+| `tenantId` | string | No | Destination tenant ID or slug. Default: selected tenant |
+
+### Example
+
+```
+import_metadata({
+  metadata: '{"entities":[...],"version":"1.0"}'
+})
+```
+
+### Notes
+
+- The import creates entities and system fields (`isSystem=true`)
+- Custom fields (`isSystem=false`) created with `manage_custom_fields` are NOT affected
+- If an entity already exists, its system fields are updated
+- Business rules are imported as drafts
+
+## Use Cases
+
+- **Migrate between tenants** -- export from one, import into another
+- **Structure backup** -- export periodically
+- **Templates** -- create a model tenant and export to replicate
+- **Publish as app** -- `publish_app` uses export_metadata internally

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/admin/users.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/admin/users.md
@@ -1,0 +1,154 @@
+# Users and Roles
+
+Each tenant has its own user table, isolated from other tenants.
+
+## MCP Tool: `create_user`
+
+**Profile:** core
+
+Creates a user within the tenant.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tenantSlug` | string | Yes | Tenant slug |
+| `email` | string | Yes | Email (unique within the tenant) |
+| `password` | string | Yes | Password (min 8 characters, hashed) |
+| `name` | string | Yes | Full name |
+| `role` | string | No | Role: `owner`, `admin`, `member`, `viewer`. Default: `member` |
+| `permissions` | object | No | Per-entity permissions |
+| `metadata` | object | No | Additional data (phone, department, position, avatar) |
+
+### Roles
+
+| Role | Description |
+|------|-------------|
+| `owner` | Full control. Can manage everything |
+| `admin` | Can manage users and settings |
+| `member` | Can create and edit records |
+| `viewer` | Read only |
+
+### Per-Entity Permissions
+
+```json
+{
+  "entities": {
+    "productos": ["create", "read", "update", "delete"],
+    "facturas": ["read", "create"],
+    "reportes": ["read"]
+  },
+  "canManageUsers": false,
+  "canManageSettings": false
+}
+```
+
+### Example
+
+```
+create_user({
+  tenantSlug: "mi-empresa",
+  email: "vendedor@empresa.com",
+  password: "password123",
+  name: "Carlos Vendedor",
+  role: "member",
+  permissions: {
+    entities: {
+      clientes: ["create", "read", "update"],
+      productos: ["read"]
+    }
+  }
+})
+```
+
+### Login After Creating
+
+The user can authenticate via REST:
+
+```bash
+curl -X POST "https://api.fyso.dev/api/auth/tenant/login" \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-ID: mi-empresa" \
+  -d '{"email":"vendedor@empresa.com","password":"password123"}'
+```
+
+Or via MCP:
+
+```
+tenant_login({
+  tenantSlug: "mi-empresa",
+  email: "vendedor@empresa.com",
+  password: "password123"
+})
+```
+
+## MCP Tool: `list_users`
+
+**Profile:** core
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tenantSlug` | string | No | Tenant slug. Default: selected tenant |
+
+### Example
+
+```
+list_users({ tenantSlug: "mi-empresa" })
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "users": [
+    {
+      "id": "uuid",
+      "email": "admin@empresa.com",
+      "name": "Admin Principal",
+      "role": "owner",
+      "isActive": true,
+      "lastLogin": "2026-02-18T10:00:00Z"
+    }
+  ],
+  "total": 2
+}
+```
+
+Passwords are never returned.
+
+## MCP Tool: `tenant_login`
+
+**Profile:** advanced
+
+Login as a tenant user. Returns a JWT for use with the REST API.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tenantSlug` | string | Yes | Tenant slug |
+| `email` | string | Yes | User email |
+| `password` | string | Yes | Password |
+
+### Response
+
+```json
+{
+  "success": true,
+  "token": "eyJhbGci...",
+  "user": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "name": "Nombre",
+    "role": "member"
+  },
+  "usage": {
+    "header": "Authorization",
+    "value": "Bearer eyJhbGci...",
+    "note": "Use this token in the Authorization header for REST API calls"
+  }
+}
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/api/mcp-tools.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/api/mcp-tools.md
@@ -1,0 +1,142 @@
+# Complete MCP Tools Reference
+
+List of all MCP tools available in Fyso, grouped by category.
+
+## Tenant
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `list_tenants` | core | List accessible tenants |
+| `select_tenant` | core | Select active tenant for the session |
+
+## Entities
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `generate_entity` | core | Create entity with fields from JSON |
+| `list_entities` | core | List entities (published or with drafts) |
+| `get_entity_schema` | core | Get full schema with structure hints |
+| `publish_entity` | core | Publish draft entity |
+| `delete_entity` | advanced | Delete entity and records |
+| `list_entity_changes` | advanced | Version history |
+| `manage_custom_fields` | advanced | Custom fields CRUD |
+
+## Records
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `query_records` | core | Query with filters, pagination, semantic search |
+| `create_record` | core | Create record |
+| `update_record` | core | Update record (partial) |
+| `delete_record` | core | Delete record |
+
+## Business Rules
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `generate_business_rule` | core | Create rule (DSL or prompt) |
+| `list_business_rules` | core | List rules for an entity |
+| `publish_business_rule` | core | Publish draft rule |
+| `create_business_rule` | advanced | Create rule with direct DSL |
+| `get_business_rule` | advanced | View rule details |
+| `test_business_rule` | advanced | Test rule with test data |
+| `delete_business_rule` | advanced | Delete rule |
+| `get_rule_logs` | advanced | Execution logs |
+
+## Users and Authentication
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `create_user` | core | Create user in the tenant |
+| `list_users` | core | List tenant users |
+| `tenant_login` | advanced | Login as user (returns JWT) |
+
+## Files
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `upload_file` | core | Upload file to a file field (via URL or base64) |
+
+## PDF
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `generate_pdf` | core | Generate PDF from template + data |
+
+## Static Sites
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `deploy_static_site` | core | Deploy site on sites.fyso.dev |
+| `list_static_sites` | core | List active deployments |
+| `delete_static_site` | advanced | Delete site |
+
+## API and Client
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `get_rest_api_spec` | core | REST specification with example curl commands |
+| `generate_api_client` | core | Generate TypeScript client with types |
+
+## Metadata
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `export_metadata` | core | Export entities, fields, rules to JSON |
+| `import_metadata` | core | Import metadata from JSON |
+
+## Apps
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `publish_app` | core | Publish tenant as an installable app |
+| `unpublish_app` | core | Unpublish app |
+| `update_app` | core | Update app metadata |
+
+## Scheduling
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `get_available_slots` | core | Query availability |
+| `create_booking` | core | Create booking with validation |
+
+## Secrets
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `set_secret` | advanced | Store a secret |
+| `delete_secret` | advanced | Delete a secret |
+
+## Flows (automations)
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `create_flow` | advanced | Create automation |
+| `list_flows` | advanced | List flows |
+| `update_flow` | advanced | Update flow |
+| `delete_flow` | advanced | Delete flow |
+| `toggle_flow` | advanced | Enable/disable flow |
+
+## Channels and Bots (profile: all)
+
+| Tool | Description |
+|------|-------------|
+| `search_channels` | Search public channels |
+| `get_channel_info` | Channel info |
+| `get_my_channel` | My channel |
+| `get_channel_tools` | Channel tools |
+| `publish_channel` | Publish channel |
+| `update_channel` | Update channel |
+| `unpublish_channel` | Unpublish channel |
+| `set_channel_permissions` | Configure permissions |
+| `define_channel_tool` | Define channel tool |
+| `update_channel_tool` | Update tool |
+| `remove_channel_tool` | Remove tool |
+| `execute_channel_tool` | Execute another channel's tool |
+| `register_bot` | Register bot |
+| `identify_bot` | Identify bot |
+| `list_bots` | List bots |
+| `whoami_bot` | Current bot identity |
+| `revoke_bot` | Revoke bot |
+| `generate_invitation_code` | Generate invitation code |
+| `list_invitation_codes` | List codes |

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/api/rest-api.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/api/rest-api.md
@@ -1,0 +1,159 @@
+# REST API
+
+Fyso exposes a REST API for external access to tenant data.
+
+## Authentication
+
+Two available methods:
+
+### 1. Tenant User Token
+
+```bash
+# 1. Login to obtain token
+curl -X POST "https://api.fyso.dev/api/auth/tenant/login" \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-ID: mi-empresa" \
+  -d '{"email":"user@example.com","password":"password123"}'
+
+# Response:
+# { "success": true, "data": { "token": "jwt...", "user": {...} } }
+
+# 2. Use the token
+curl -H "Authorization: Bearer JWT_TOKEN" \
+  "https://api.fyso.dev/api/entities/clientes/records"
+```
+
+### 2. API Key
+
+```bash
+curl -H "Authorization: Bearer API_KEY" \
+  "https://api.fyso.dev/api/entities/clientes/records"
+
+# Or alternative:
+curl -H "X-API-Key: API_KEY" \
+  "https://api.fyso.dev/api/entities/clientes/records"
+```
+
+## CRUD Endpoints
+
+### List Records
+
+```
+GET /api/entities/{entityName}/records
+```
+
+**Query params:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | number | 1 | Page number (1-indexed) |
+| `limit` | number | 20 | Items per page (max 100) |
+| `sort` | string | - | Field to sort by |
+| `order` | string | `asc` | Direction: `asc` or `desc` |
+| `search` | string | - | Full-text search across text fields |
+| `resolve` | boolean | - | Expand relations to full objects |
+| `filter.{fieldKey}` | string | - | Filter by field (e.g., `filter.estado=activo`) |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "data": [
+      {
+        "id": "uuid",
+        "entityId": "uuid",
+        "name": "Juan Perez",
+        "data": {
+          "nombre": "Juan Perez",
+          "email": "juan@example.com"
+        },
+        "createdAt": "2026-02-03T12:51:15.352Z",
+        "updatedAt": "2026-02-03T12:51:15.352Z"
+      }
+    ],
+    "total": 42,
+    "page": 1,
+    "limit": 20,
+    "totalPages": 3
+  }
+}
+```
+
+### Get a Record
+
+```
+GET /api/entities/{entityName}/records/{id}
+```
+
+**Query params:** `resolve` (boolean)
+
+### Create a Record
+
+```
+POST /api/entities/{entityName}/records
+Content-Type: application/json
+
+{
+  "nombre": "Juan Perez",
+  "email": "juan@example.com"
+}
+```
+
+### Update a Record
+
+```
+PUT /api/entities/{entityName}/records/{id}
+Content-Type: application/json
+
+{
+  "email": "juan.nuevo@example.com"
+}
+```
+
+Supports partial updates.
+
+### Delete a Record
+
+```
+DELETE /api/entities/{entityName}/records/{id}
+```
+
+## Record Structure
+
+Entity fields are inside `record.data`:
+
+```
+record.data.email     -- CORRECT
+record.email          -- INCORRECT
+```
+
+## Error Codes
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `NOT_FOUND` | 404 | Entity or record not found |
+| `VALIDATION_ERROR` | 400 | Invalid data |
+| `BUSINESS_RULE_ERROR` | 400 | A business rule prevented the operation |
+| `UNAUTHORIZED` | 401 | Missing or invalid API key |
+| `FORBIDDEN` | 403 | No permissions for the operation |
+| `INTERNAL_ERROR` | 500 | Internal server error |
+
+**Error format:**
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "El campo 'nombre' es obligatorio"
+  }
+}
+```
+
+## Related MCP Tools
+
+- `get_rest_api_spec` -- Generates the full specification with example curl commands
+- `generate_api_client` -- Generates a complete TypeScript client with types
+- `tenant_login` -- Login as a tenant user (returns JWT)

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/api/tool-profiles.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/api/tool-profiles.md
@@ -1,0 +1,76 @@
+# Tool Profiles
+
+Profiles control which MCP tools are available to the agent.
+
+## Configuration
+
+Environment variable: `FYSO_TOOLS`
+
+| Value | Description |
+|-------|-------------|
+| `core` | Default. ~26 essential tools for daily use |
+| `advanced` | ~38 tools. Adds power-user features: delete, test, flows, secrets, logs |
+| `all` | ~49 tools. Everything, including channels and bots |
+
+## Profile: core
+
+Tools for day-to-day app building:
+
+```
+list_tenants, select_tenant,
+generate_entity, list_entities, get_entity_schema, publish_entity,
+query_records, create_record, update_record, delete_record,
+generate_business_rule, list_business_rules, publish_business_rule,
+create_user, list_users,
+deploy_static_site, list_static_sites,
+export_metadata, import_metadata,
+get_rest_api_spec, generate_api_client,
+publish_app, unpublish_app, update_app,
+get_available_slots, create_booking,
+generate_pdf, upload_file
+```
+
+## Profile: advanced
+
+Everything in `core` plus:
+
+```
+delete_entity, list_entity_changes, manage_custom_fields,
+create_business_rule, get_business_rule, test_business_rule,
+delete_business_rule,
+tenant_login,
+delete_static_site,
+set_secret, delete_secret,
+create_flow, list_flows, update_flow, delete_flow, toggle_flow,
+get_rule_logs
+```
+
+## Profile: all
+
+Everything in `advanced` plus channels, bots, and invitation codes:
+
+```
+search_channels, get_channel_info, get_my_channel, get_channel_tools,
+publish_channel, update_channel, unpublish_channel, set_channel_permissions,
+define_channel_tool, update_channel_tool, remove_channel_tool, execute_channel_tool,
+register_bot, identify_bot, list_bots, whoami_bot, revoke_bot,
+generate_invitation_code, list_invitation_codes
+```
+
+## Configuration Example
+
+```json
+{
+  "mcpServers": {
+    "fyso": {
+      "command": "npx",
+      "args": ["-y", "@fyso/mcp-server"],
+      "env": {
+        "FYSO_API_KEY": "...",
+        "FYSO_API_URL": "https://api.fyso.dev/api",
+        "FYSO_TOOLS": "advanced"
+      }
+    }
+  }
+}
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/billing/plans.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/billing/plans.md
@@ -1,0 +1,47 @@
+# Plans and Limits
+
+Fyso offers plans with different usage limits.
+
+## Plan Comparison
+
+| Resource | Free | Pro | Beta |
+|----------|------|-----|------|
+| Entities | 3 | Unlimited | Unlimited |
+| Records | 500 | Unlimited | Unlimited |
+| Static sites | 1 | Unlimited | Unlimited |
+| Users | 2 | Unlimited | Unlimited |
+
+## Free Plan
+
+Included at no cost. Ideal for testing the platform or small projects.
+
+**Limits:**
+- Up to 3 entities
+- Up to 500 total records (across all entities)
+- 1 static site
+- 2 tenant users
+
+When a limit is reached, the operation is rejected with a descriptive message.
+
+## Pro Plan
+
+Full plan with no usage restrictions.
+
+**Includes:**
+- Unlimited entities
+- Unlimited records
+- Unlimited static sites
+- Unlimited users
+
+## Beta Plan
+
+Full access during the Fyso beta phase. Same limits as Pro.
+
+## Check Current Usage
+
+Usage can be checked from the admin panel. It shows:
+- Current plan
+- Entities: used / limit
+- Records: used / limit
+- Sites: used / limit
+- Users: used / limit

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/billing/stripe.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/billing/stripe.md
@@ -1,0 +1,38 @@
+# Stripe and Payments
+
+Fyso billing is managed through Stripe.
+
+## Subscription Flow
+
+1. The user chooses the Pro plan from the admin panel
+2. A Stripe Checkout session is created
+3. The user completes the payment on Stripe
+4. Fyso receives the webhook and updates the tenant's plan
+5. Limits are applied immediately
+
+## Customer Portal
+
+Users with an active subscription can access the Stripe portal to:
+
+- View invoices and receipts
+- Update payment method
+- Cancel subscription
+
+## Webhooks
+
+Fyso processes the following Stripe events:
+
+- `checkout.session.completed` -- New subscription completed
+- `customer.subscription.updated` -- Subscription changes
+- `customer.subscription.deleted` -- Subscription canceled
+- `invoice.payment_failed` -- Failed payment
+
+## Configuration (admin)
+
+Required environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `STRIPE_SECRET_KEY` | Stripe secret key |
+| `STRIPE_WEBHOOK_SECRET` | Secret for verifying webhooks |
+| `STRIPE_PRICE_ID` | Price ID for the Pro plan |

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/business-rules/dsl-reference.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/business-rules/dsl-reference.md
@@ -1,0 +1,227 @@
+# DSL Reference
+
+Complete reference for the DSL (Domain Specific Language) for business rules in Fyso.
+
+## General Structure
+
+```json
+{
+  "type": "compute | validate | action",
+  "triggers": ["campo1", "campo2"],
+  "triggerType": "field_change | before_save | after_save | on_load",
+  "compute": { ... },
+  "validate": [ ... ],
+  "transform": { ... },
+  "actions": [ ... ]
+}
+```
+
+## Compute
+
+Calculates values automatically. Supports several formats:
+
+### Simple Formula (shorthand)
+
+```json
+{
+  "compute": {
+    "total": "cantidad * precio"
+  }
+}
+```
+
+The shorthand is internally normalized to:
+
+```json
+{
+  "compute": {
+    "total": { "type": "formula", "expression": "cantidad * precio" }
+  }
+}
+```
+
+### Explicit Formula
+
+```json
+{
+  "compute": {
+    "iva": { "type": "formula", "expression": "subtotal * 0.21" },
+    "total": { "type": "formula", "expression": "subtotal + iva" }
+  }
+}
+```
+
+### Conditional
+
+Calculates a value based on conditions:
+
+```json
+{
+  "compute": {
+    "descuento": {
+      "type": "conditional",
+      "conditions": [
+        { "when": "cantidad >= 100", "then": "0.15" },
+        { "when": "cantidad >= 50", "then": "0.10" },
+        { "when": "cantidad >= 10", "then": "0.05" }
+      ],
+      "default": "0"
+    }
+  }
+}
+```
+
+### Lookup
+
+Looks up a value in another entity:
+
+```json
+{
+  "compute": {
+    "precio_unitario": {
+      "type": "lookup",
+      "entity": "productos",
+      "matchField": "id",
+      "matchValue": "producto_id",
+      "resultField": "precio"
+    }
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `entity` | string | Entity to search in |
+| `matchField` | string | Field in the target entity to match against |
+| `matchValue` | string | Field in the current record containing the value to search for |
+| `resultField` | string | Field in the target entity whose value to return |
+
+### Aggregate
+
+Aggregates values from multiple records of another entity:
+
+```json
+{
+  "compute": {
+    "total_lineas": {
+      "type": "aggregate",
+      "entity": "lineas_factura",
+      "aggregateOp": "sum",
+      "aggregateField": "subtotal",
+      "filter": { "factura_id": "id" }
+    },
+    "cantidad_items": {
+      "type": "aggregate",
+      "entity": "lineas_factura",
+      "aggregateOp": "count",
+      "filter": { "factura_id": "id" }
+    }
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `entity` | string | Entity to aggregate |
+| `aggregateOp` | string | Operation: `"sum"` or `"count"` |
+| `aggregateField` | string | Field to sum (required for `sum`) |
+| `filter` | object | Filter: `{ target_field: "current_field" }` |
+
+## Validate
+
+Array of validation rules:
+
+```json
+{
+  "validate": [
+    {
+      "id": "precio_positivo",
+      "condition": "precio > 0",
+      "message": "El precio debe ser mayor a cero",
+      "severity": "error",
+      "field": "precio"
+    }
+  ]
+}
+```
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `id` | string | Yes | Unique identifier for the validation |
+| `condition` | string | Yes | Boolean expression that must be true |
+| `message` | string | Yes | Error message if the condition is false |
+| `severity` | string | Yes | `"error"` (blocks save), `"warning"`, `"info"` |
+| `field` | string | No | Field to associate the error with in the UI |
+
+## Transform
+
+Transforms field values:
+
+```json
+{
+  "transform": {
+    "nombre": { "type": "uppercase" },
+    "email": { "type": "lowercase" },
+    "descripcion": { "type": "trim" },
+    "precio": { "type": "round", "decimals": 2 }
+  }
+}
+```
+
+| Type | Description |
+|------|-------------|
+| `uppercase` | Converts to uppercase |
+| `lowercase` | Converts to lowercase |
+| `trim` | Removes leading and trailing whitespace |
+| `round` | Rounds to N decimal places |
+
+## Actions
+
+Side effects that execute after saving:
+
+```json
+{
+  "actions": [
+    {
+      "type": "update_related",
+      "entity": "pedidos",
+      "recordId": "pedido_id",
+      "data": {
+        "total": {
+          "type": "aggregate",
+          "entity": "lineas",
+          "aggregateOp": "sum",
+          "aggregateField": "subtotal",
+          "filter": { "pedido_id": "pedido_id" }
+        }
+      }
+    }
+  ]
+}
+```
+
+## Allowed Operators
+
+| Category | Operators |
+|----------|-----------|
+| Arithmetic | `+`, `-`, `*`, `/` |
+| Comparison | `>`, `<`, `>=`, `<=`, `==`, `!=` |
+| Logical | `and`, `or` |
+
+## Allowed Functions
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `round(x, n)` | Rounds to n decimal places | `round(total, 2)` |
+| `coalesce(a, b)` | First non-null value | `coalesce(descuento, 0)` |
+| `abs(x)` | Absolute value | `abs(diferencia)` |
+| `min(a, b)` | Minimum | `min(stock, pedido)` |
+| `max(a, b)` | Maximum | `max(precio, precio_minimo)` |
+| `floor(x)` | Round down | `floor(cantidad)` |
+| `ceil(x)` | Round up | `ceil(horas)` |
+| `len(s)` | String length | `len(nombre)` |
+| `upper(s)` | Uppercase | `upper(codigo)` |
+| `lower(s)` | Lowercase | `lower(email)` |
+| `trim(s)` | Remove whitespace | `trim(nombre)` |
+| `now()` | Current date and time | `now()` |
+| `today()` | Current date | `today()` |

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/business-rules/examples.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/business-rules/examples.md
@@ -1,0 +1,182 @@
+# Business Rule Examples
+
+Common patterns for business rules in Fyso.
+
+## Invoice Calculation with Tax
+
+Automatically calculates subtotal, tax, and total.
+
+```
+generate_business_rule({
+  entityName: "facturas",
+  dsl: {
+    type: "compute",
+    triggers: ["cantidad", "precio_unitario", "iva_pct"],
+    compute: {
+      subtotal: "cantidad * precio_unitario",
+      iva: "subtotal * iva_pct / 100",
+      total: "subtotal + iva"
+    }
+  },
+  auto_publish: true
+})
+```
+
+## Validate Minimum Stock
+
+Prevents saving if stock is negative.
+
+```
+generate_business_rule({
+  entityName: "productos",
+  dsl: {
+    type: "validate",
+    triggers: ["stock"],
+    validate: [{
+      id: "stock_no_negativo",
+      condition: "stock >= 0",
+      message: "El stock no puede ser negativo",
+      severity: "error",
+      field: "stock"
+    }]
+  },
+  auto_publish: true
+})
+```
+
+## Volume Discount
+
+Applies a discount based on the purchased quantity.
+
+```
+generate_business_rule({
+  entityName: "lineas_pedido",
+  dsl: {
+    type: "compute",
+    triggers: ["cantidad"],
+    compute: {
+      descuento_pct: {
+        type: "conditional",
+        conditions: [
+          { when: "cantidad >= 100", then: "15" },
+          { when: "cantidad >= 50", then: "10" },
+          { when: "cantidad >= 20", then: "5" }
+        ],
+        default: "0"
+      },
+      descuento: "subtotal * descuento_pct / 100",
+      total: "subtotal - descuento"
+    }
+  },
+  auto_publish: true
+})
+```
+
+## Price Lookup from Catalog
+
+Looks up the product price when selected in an order line.
+
+```
+generate_business_rule({
+  entityName: "lineas_pedido",
+  dsl: {
+    type: "compute",
+    triggers: ["producto_id"],
+    compute: {
+      precio_unitario: {
+        type: "lookup",
+        entity: "productos",
+        matchField: "id",
+        matchValue: "producto_id",
+        resultField: "precio"
+      },
+      subtotal: "cantidad * precio_unitario"
+    }
+  },
+  auto_publish: true
+})
+```
+
+## Update Parent Order Total
+
+When an order line is modified, recalculates the order total.
+
+```
+generate_business_rule({
+  entityName: "lineas_pedido",
+  dsl: {
+    type: "action",
+    triggerType: "after_save",
+    triggers: ["subtotal"],
+    actions: [{
+      type: "update_related",
+      entity: "pedidos",
+      recordId: "pedido_id",
+      data: {
+        total: {
+          type: "aggregate",
+          entity: "lineas_pedido",
+          aggregateOp: "sum",
+          aggregateField: "subtotal",
+          filter: { pedido_id: "pedido_id" }
+        },
+        cantidad_items: {
+          type: "aggregate",
+          entity: "lineas_pedido",
+          aggregateOp: "count",
+          filter: { pedido_id: "pedido_id" }
+        }
+      }
+    }]
+  },
+  auto_publish: true
+})
+```
+
+## Normalize Text
+
+Converts name to uppercase and trims whitespace from email.
+
+```
+generate_business_rule({
+  entityName: "clientes",
+  dsl: {
+    type: "compute",
+    triggers: ["nombre", "email"],
+    transform: {
+      nombre: { type: "uppercase" },
+      email: { type: "trim" }
+    }
+  },
+  auto_publish: true
+})
+```
+
+## Multiple Validations
+
+```
+generate_business_rule({
+  entityName: "empleados",
+  dsl: {
+    type: "validate",
+    triggers: ["salario", "fecha_ingreso"],
+    validate: [
+      {
+        id: "salario_positivo",
+        condition: "salario > 0",
+        message: "El salario debe ser mayor a cero",
+        severity: "error",
+        field: "salario"
+      },
+      {
+        id: "salario_razonable",
+        condition: "salario <= 1000000",
+        message: "Verificar: el salario parece muy alto",
+        severity: "warning",
+        field: "salario"
+      }
+    ]
+  },
+  auto_publish: true
+})
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/business-rules/execution-logs.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/business-rules/execution-logs.md
@@ -1,0 +1,67 @@
+# Execution Logs
+
+Execution logs allow you to debug business rules and understand what happened in each execution.
+
+## MCP Tool: `get_rule_logs`
+
+**Profile:** advanced
+
+Gets the execution logs of rules for an entity.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+| `ruleId` | string | No | Filter by specific rule |
+| `limit` | number | No | Maximum logs to return |
+
+### Example
+
+```
+get_rule_logs({
+  entityName: "facturas",
+  limit: 20
+})
+```
+
+### Information in the Logs
+
+Each log includes:
+
+- Rule that was executed (name and ID)
+- Affected record (ID)
+- Trigger that fired the execution
+- Result: success, failure, or error
+- Input and output values
+- Timestamp
+
+## MCP Tool: `test_business_rule`
+
+**Profile:** advanced
+
+Tests a rule with test data without affecting real records.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+| `ruleId` | string | Yes | ID of the rule to test |
+| `testData` | object | Yes | Test data |
+
+### Example
+
+```
+test_business_rule({
+  entityName: "facturas",
+  ruleId: "uuid-de-la-regla",
+  testData: {
+    cantidad: 10,
+    precio_unitario: 100,
+    iva_pct: 21
+  }
+})
+```
+
+The result shows the calculated values without saving anything to the database.

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/business-rules/overview.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/business-rules/overview.md
@@ -1,0 +1,92 @@
+# Business Rules
+
+Business rules automate logic over data: computations, validations, and actions.
+
+## Rule Types
+
+### compute
+
+Calculates fields automatically when other fields change.
+
+```json
+{
+  "type": "compute",
+  "triggers": ["cantidad", "precio"],
+  "compute": {
+    "total": "cantidad * precio"
+  }
+}
+```
+
+### validate
+
+Validates data before saving the record. If the validation fails, the save is rejected.
+
+```json
+{
+  "type": "validate",
+  "triggers": ["precio"],
+  "validate": [{
+    "id": "precio_positivo",
+    "condition": "precio > 0",
+    "message": "El precio debe ser positivo",
+    "severity": "error"
+  }]
+}
+```
+
+### action
+
+Executes side effects after saving (e.g., update related records).
+
+```json
+{
+  "type": "action",
+  "triggerType": "after_save",
+  "triggers": ["subtotal"],
+  "actions": [{
+    "type": "update_related",
+    "entity": "pedidos",
+    "recordId": "pedido_id",
+    "data": {
+      "total": {
+        "type": "aggregate",
+        "entity": "lineas",
+        "aggregateOp": "sum",
+        "aggregateField": "subtotal",
+        "filter": { "pedido_id": "pedido_id" }
+      }
+    }
+  }]
+}
+```
+
+## Lifecycle
+
+Rules have the same draft/published lifecycle as entities:
+
+1. Created as a **draft**
+2. Published with `publish_business_rule`
+3. Only published rules are executed
+
+## Trigger Types
+
+| Type | When it executes |
+|------|-----------------|
+| `field_change` | When one of the trigger fields changes (default) |
+| `before_save` | Before saving the record |
+| `after_save` | After saving the record |
+| `on_load` | When loading the record |
+
+## Related MCP Tools
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `generate_business_rule` | core | Create rule (via DSL or prompt) |
+| `create_business_rule` | advanced | Create rule with direct DSL |
+| `list_business_rules` | core | List rules for an entity |
+| `get_business_rule` | advanced | View rule details |
+| `test_business_rule` | advanced | Test a rule with test data |
+| `publish_business_rule` | core | Publish a draft rule |
+| `delete_business_rule` | advanced | Delete a rule |
+| `get_rule_logs` | advanced | View execution logs |

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/deployment/github-actions.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/deployment/github-actions.md
@@ -1,0 +1,52 @@
+# CI/CD with GitHub Actions
+
+Example configuration for automatically deploying to Fyso Sites from GitHub Actions.
+
+## Basic Workflow
+
+```yaml
+name: Deploy to Fyso Sites
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Deploy to Fyso
+        env:
+          FYSO_API_KEY: ${{ secrets.FYSO_API_KEY }}
+          FYSO_API_URL: ${{ secrets.FYSO_API_URL }}
+        run: |
+          cd dist
+          zip -qr /tmp/site.zip .
+          curl -X POST "$FYSO_API_URL/sites/mi-portfolio/deploy" \
+            -H "Authorization: Bearer $FYSO_API_KEY" \
+            -F "file=@/tmp/site.zip"
+```
+
+## Required Secrets
+
+Configure in Settings > Secrets and variables > Actions:
+
+| Secret | Value |
+|--------|-------|
+| `FYSO_API_KEY` | Your Fyso API key |
+| `FYSO_API_URL` | API URL (e.g., `https://api.fyso.dev/api`) |
+
+## Notes
+
+- The build directory depends on the framework (`dist/`, `build/`, `out/`)
+- The subdomain must exist beforehand (create with `deploy_static_site` the first time)
+- Successive deployments replace the previous content

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/deployment/static-sites.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/deployment/static-sites.md
@@ -1,0 +1,104 @@
+# Static Sites
+
+Fyso allows deploying static sites (Astro, Vite, Next.js export, etc.) on subdomains of `sites.fyso.dev`.
+
+## MCP Tool: `deploy_static_site`
+
+**Profile:** core
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `subdomain` | string | Yes | Subdomain (e.g., `"mi-portfolio"` -> `mi-portfolio.sites.fyso.dev`) |
+| `path` | string | Conditional | Absolute path to the build directory (e.g., `/home/user/my-site/dist`) |
+| `bundle_base64` | string | Conditional | ZIP in base64 (only for sites < 5KB) |
+
+Either `path` or `bundle_base64` must be provided.
+
+### Subdomain Restrictions
+
+- Only lowercase letters, numbers, and hyphens
+- No spaces or special characters
+
+### Local Mode (MCP has filesystem access)
+
+The MCP server compresses the directory and uploads it automatically:
+
+```
+deploy_static_site({
+  subdomain: "mi-portfolio",
+  path: "/home/user/my-site/dist"
+})
+```
+
+### Remote Mode (MCP does not have filesystem access)
+
+If the MCP server cannot access the path, it returns a `curl` command to execute manually:
+
+```json
+{
+  "success": false,
+  "action_required": "run_command",
+  "message": "The MCP server cannot access your local filesystem...",
+  "command": "cd \"/home/user/my-site/dist\" && zip -qr /tmp/_fyso_deploy.zip . && curl ...",
+  "token_expires_in": 300,
+  "token_note": "The deploy token in this command expires in 5 minutes."
+}
+```
+
+The agent must execute the returned command using the Bash tool.
+
+### Successful Response
+
+```json
+{
+  "success": true,
+  "message": "Site deployed successfully",
+  "data": {
+    "url": "https://mi-portfolio.sites.fyso.dev",
+    "subdomain": "mi-portfolio"
+  }
+}
+```
+
+## MCP Tool: `list_static_sites`
+
+**Profile:** core
+
+Lists all active deployments.
+
+```
+list_static_sites()
+```
+
+Returns subdomain, URL, size, and deployment date.
+
+## MCP Tool: `delete_static_site`
+
+**Profile:** advanced
+
+Deletes a deployed site.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `subdomain` | string | Yes | Subdomain of the site to delete |
+
+## Limits
+
+| Plan | Sites |
+|------|-------|
+| Free | 1 |
+| Pro | Unlimited |
+
+## Supported Frameworks
+
+Any framework that generates static output:
+
+- **Astro** -- `npm run build` -> `dist/`
+- **Vite** -- `npm run build` -> `dist/`
+- **Next.js** (export) -- `next export` -> `out/`
+- **Create React App** -- `npm run build` -> `build/`
+- **Plain HTML/CSS/JS** -- directory with `index.html`

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/entities/add-fields.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/entities/add-fields.md
@@ -1,0 +1,126 @@
+# Add and Manage Fields
+
+Fields can be added when creating the entity (via `generate_entity`) or afterwards using `manage_custom_fields`.
+
+## MCP Tool: `manage_custom_fields`
+
+**Profile:** advanced
+
+Manages custom fields of an entity. Allows listing, adding, updating, and deleting user-created fields. Custom fields are NOT affected by metadata import/export.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | `"list"`, `"add"`, `"update"`, `"delete"` |
+| `entityName` | string | Yes | Entity name |
+| `fieldId` | string | Conditional | Field ID (required for update and delete) |
+| `type` | string | No | Filter for list: `"custom"`, `"system"`, `"all"`. Default: `"custom"` |
+| `fieldData` | object | Conditional | Field data (required for add and update) |
+
+### List fields
+
+```
+manage_custom_fields({
+  action: "list",
+  entityName: "clientes",
+  type: "all"
+})
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "entity": "clientes",
+  "filter": "all",
+  "count": 5,
+  "fields": [
+    {
+      "id": "uuid",
+      "name": "Nombre",
+      "fieldKey": "nombre",
+      "fieldType": "text",
+      "isSystem": false,
+      "isRequired": true,
+      "description": "Nombre del cliente",
+      "config": {}
+    }
+  ]
+}
+```
+
+### Add a field
+
+```
+manage_custom_fields({
+  action: "add",
+  entityName: "clientes",
+  fieldData: {
+    name: "Direccion",
+    fieldKey: "direccion",
+    fieldType: "text",
+    description: "Direccion del cliente",
+    isRequired: false
+  }
+})
+```
+
+For fields with configuration:
+
+```
+manage_custom_fields({
+  action: "add",
+  entityName: "clientes",
+  fieldData: {
+    name: "Estado",
+    fieldKey: "estado",
+    fieldType: "select",
+    config: {
+      options: ["activo", "inactivo", "suspendido"]
+    }
+  }
+})
+```
+
+**Required fields in fieldData for add:**
+- `name` -- Display name
+- `fieldKey` -- Technical key (snake_case)
+- `fieldType` -- Data type
+
+### Update a field
+
+```
+manage_custom_fields({
+  action: "update",
+  entityName: "clientes",
+  fieldId: "uuid-del-campo",
+  fieldData: {
+    name: "Nombre completo",
+    isRequired: true,
+    description: "Nombre y apellido del cliente"
+  }
+})
+```
+
+**Updatable fields:** `name`, `description`, `isRequired`, `isUnique`, `isVisible`, `displayOrder`, `config`.
+
+### Delete a field
+
+```
+manage_custom_fields({
+  action: "delete",
+  entityName: "clientes",
+  fieldId: "uuid-del-campo"
+})
+```
+
+Only custom fields (`isSystem=false`) can be deleted. System fields are protected.
+
+## System vs Custom fields
+
+| Type | Created by | Editable | Affected by import/export |
+|------|-----------|----------|---------------------------|
+| System | `generate_entity` / metadata import | No | Yes |
+| Custom | `manage_custom_fields` | Yes | No |

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/entities/create-entity.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/entities/create-entity.md
@@ -1,0 +1,208 @@
+# Create Entities
+
+An entity defines the data structure of your application. It is equivalent to a table.
+
+## MCP Tool: `generate_entity`
+
+**Profile:** core
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `definition` | object | Yes | Structure of the entity and its fields |
+| `auto_publish` | boolean | No | Publish automatically (default: false) |
+| `version_message` | string | Conditional | Required if `auto_publish=true` |
+
+### Structure of `definition`
+
+```json
+{
+  "entity": {
+    "name": "productos",
+    "displayName": "Productos",
+    "description": "Catalogo de productos",
+    "icon": "box"
+  },
+  "fields": [
+    {
+      "name": "Nombre",
+      "fieldKey": "nombre",
+      "fieldType": "text",
+      "isRequired": true,
+      "isUnique": false,
+      "description": "Nombre del producto",
+      "config": {}
+    }
+  ]
+}
+```
+
+### Properties of `entity`
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | string | Yes | Technical name (snake_case) |
+| `displayName` | string | No | Display name. Default: `name` |
+| `description` | string | No | Entity description |
+| `icon` | string | No | Icon. Default: `"box"` |
+
+### Properties of each `field`
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | string | Yes | Display name of the field |
+| `fieldKey` | string | Yes | Technical key (snake_case, unique) |
+| `fieldType` | string | Yes | Data type (see [Field Types](field-types.md)) |
+| `isRequired` | boolean | No | Required. Default: false |
+| `isUnique` | boolean | No | Unique value. Default: false |
+| `description` | string | No | Field description |
+| `config` | object | No | Type-specific configuration |
+
+### Full Example
+
+```
+generate_entity({
+  definition: {
+    entity: {
+      name: "facturas",
+      displayName: "Facturas",
+      description: "Facturas de venta",
+      icon: "file-text"
+    },
+    fields: [
+      { name: "Numero", fieldKey: "numero", fieldType: "text", isRequired: true, isUnique: true },
+      { name: "Cliente", fieldKey: "cliente_id", fieldType: "relation", config: { relatedEntity: "clientes" } },
+      { name: "Fecha", fieldKey: "fecha", fieldType: "date", isRequired: true },
+      { name: "Estado", fieldKey: "estado", fieldType: "select", config: { options: ["borrador", "emitida", "pagada", "anulada"] } },
+      { name: "Total", fieldKey: "total", fieldType: "number" },
+      { name: "Archivo PDF", fieldKey: "pdf_documento", fieldType: "file" }
+    ]
+  },
+  auto_publish: true,
+  version_message: "Crear entidad facturas"
+})
+```
+
+### Successful Response
+
+```json
+{
+  "success": true,
+  "message": "Entity \"facturas\" created successfully",
+  "fieldsProcessed": 6,
+  "entity": {
+    "name": "facturas",
+    "displayName": "Facturas",
+    "description": "Facturas de venta",
+    "fields": [
+      { "name": "Numero", "fieldKey": "numero", "type": "text", "required": true },
+      { "name": "Cliente", "fieldKey": "cliente_id", "type": "relation", "required": false }
+    ]
+  }
+}
+```
+
+## MCP Tool: `list_entities`
+
+**Profile:** core
+
+Lists the entities of the tenant. By default, only shows published ones.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `include_drafts` | boolean | No | Include drafts. Default: false |
+
+### Example
+
+```
+list_entities({ include_drafts: true })
+```
+
+### Response
+
+```json
+[
+  {
+    "name": "clientes",
+    "displayName": "Clientes",
+    "description": "Base de clientes",
+    "fieldCount": 5,
+    "status": "published",
+    "version": 2
+  }
+]
+```
+
+## MCP Tool: `get_entity_schema`
+
+**Profile:** core
+
+Gets the full definition of an entity, including structure hints for complex types (location, file, select).
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+| `version` | string | No | Version: number, `"draft"`, or `"published"` (default) |
+
+### Example
+
+```
+get_entity_schema({ entityName: "clientes", version: "published" })
+```
+
+### Response
+
+```json
+{
+  "name": "clientes",
+  "displayName": "Clientes",
+  "description": "Base de clientes",
+  "version": 2,
+  "status": "published",
+  "fields": [
+    {
+      "name": "Nombre",
+      "fieldKey": "nombre",
+      "type": "text",
+      "required": true,
+      "isSystem": false,
+      "description": "Nombre del cliente",
+      "config": {}
+    },
+    {
+      "name": "Ubicacion",
+      "fieldKey": "ubicacion",
+      "type": "location",
+      "required": false,
+      "isSystem": false,
+      "config": { "displayFormat": "both" },
+      "structureHint": {
+        "format": "{ lat: number, lng: number, address?: string, city?: string, country?: string }",
+        "description": "Geographic location with coordinates and optional address components",
+        "configOptions": {
+          "displayFormat": "\"map\" | \"text\" | \"both\" (default: \"both\")",
+          "defaultZoom": "number 1-20 (default: 13)",
+          "defaultCenter": "{ lat: number, lng: number }"
+        }
+      }
+    }
+  ]
+}
+```
+
+## MCP Tool: `delete_entity`
+
+**Profile:** advanced
+
+Deletes an entity and all its records. This action cannot be undone.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Name of the entity to delete |

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/entities/field-types.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/entities/field-types.md
@@ -1,0 +1,199 @@
+# Field Types
+
+Complete reference for the field types available in Fyso.
+
+## text
+
+Short single-line text.
+
+- **Storage:** string
+- **Config:** none
+- **Example value:** `"Juan Perez"`
+
+## textarea
+
+Long multi-line text.
+
+- **Storage:** string
+- **Config:** none
+- **Example value:** `"Long description\nwith line breaks"`
+
+## number
+
+Numeric value (integer or decimal).
+
+- **Storage:** number
+- **Config:** none
+- **Example value:** `150.50`
+
+## email
+
+Email address.
+
+- **Storage:** string
+- **Config:** none
+- **Example value:** `"juan@example.com"`
+
+## phone
+
+Phone number.
+
+- **Storage:** string
+- **Config:** none
+- **Example value:** `"+54 11 1234-5678"`
+
+## date
+
+Date (without time).
+
+- **Storage:** string (ISO format `YYYY-MM-DD`)
+- **Config:** none
+- **Example value:** `"2026-02-18"`
+
+## boolean
+
+True/false value.
+
+- **Storage:** boolean
+- **Config:** none
+- **Example value:** `true`
+
+## select
+
+Selection from a predefined list of options.
+
+- **Storage:** string (the value of the selected option)
+- **Config:**
+
+| Config | Type | Description |
+|--------|------|-------------|
+| `options` | `string[]` or `{value, label}[]` | Available options |
+
+- **Config example:**
+
+```json
+{
+  "options": ["activo", "inactivo", "pendiente"]
+}
+```
+
+Or with labels:
+
+```json
+{
+  "options": [
+    { "value": "active", "label": "Activo" },
+    { "value": "inactive", "label": "Inactivo" }
+  ]
+}
+```
+
+- **Example value:** `"activo"`
+
+## relation
+
+Reference to a record in another entity.
+
+- **Storage:** string (UUID of the related record)
+- **Config:**
+
+| Config | Type | Description |
+|--------|------|-------------|
+| `relatedEntity` | string | Name of the related entity |
+
+- **Config example:**
+
+```json
+{
+  "relatedEntity": "clientes"
+}
+```
+
+- **Example value:** `"6bd2d1db-d104-4a15-977a-a759c38608a9"`
+
+When querying records with `resolve=true`, the relation is expanded to the full record.
+
+## file
+
+File attachment. Uploaded using the `upload_file` tool.
+
+- **Storage:** object
+
+```json
+{
+  "key": "uploads/file.pdf",
+  "url": "/files/file.pdf",
+  "name": "file.pdf",
+  "size": 1024,
+  "mimeType": "application/pdf"
+}
+```
+
+- **Config:**
+
+| Config | Type | Description |
+|--------|------|-------------|
+| `accept` | `string[]` | Allowed MIME types (e.g., `["image/*", "application/pdf"]`) |
+| `maxSize` | number | Maximum size in bytes |
+| `multiple` | boolean | Allow multiple files. Default: false |
+| `maxFiles` | number | Maximum files when `multiple=true` |
+
+- **Config example:**
+
+```json
+{
+  "accept": ["image/*", "application/pdf"],
+  "maxSize": 5242880,
+  "multiple": false
+}
+```
+
+## location
+
+Geographic location with coordinates and optional address data.
+
+- **Storage:** object
+
+```json
+{
+  "lat": -34.6037,
+  "lng": -58.3816,
+  "address": "Av. 9 de Julio 1000",
+  "city": "Buenos Aires",
+  "country": "Argentina"
+}
+```
+
+- **Config:**
+
+| Config | Type | Description |
+|--------|------|-------------|
+| `displayFormat` | string | `"map"`, `"text"`, or `"both"` (default: `"both"`) |
+| `defaultZoom` | number | Initial map zoom (1-20, default: 13) |
+| `defaultCenter` | object | Initial center: `{ lat: number, lng: number }` |
+
+- **Config example:**
+
+```json
+{
+  "displayFormat": "both",
+  "defaultZoom": 15,
+  "defaultCenter": { "lat": -34.6037, "lng": -58.3816 }
+}
+```
+
+## Type Summary
+
+| Type | Stores | Required Config |
+|------|--------|-----------------|
+| `text` | string | - |
+| `textarea` | string | - |
+| `number` | number | - |
+| `email` | string | - |
+| `phone` | string | - |
+| `date` | string | - |
+| `boolean` | boolean | - |
+| `select` | string | `options` |
+| `relation` | string (UUID) | `relatedEntity` |
+| `file` | object | `accept`, `maxSize`, `multiple` |
+| `location` | object | `displayFormat`, `defaultZoom` |

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/entities/publish.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/entities/publish.md
@@ -1,0 +1,65 @@
+# Publish Entities
+
+Entities in Fyso have a draft/published lifecycle. Changes are not visible until they are published.
+
+## Publishing Flow
+
+1. Create the entity with `generate_entity` -- it is created as a **draft** (unless you use `auto_publish`)
+2. Verify the schema with `get_entity_schema({ version: "draft" })`
+3. Publish with `publish_entity`
+
+Each publication creates a new **version** with a descriptive message.
+
+## MCP Tool: `publish_entity`
+
+**Profile:** core
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+| `version_message` | string | Yes | Version message (similar to a commit message) |
+
+### Example
+
+```
+publish_entity({
+  entityName: "productos",
+  version_message: "Agregar campo precio_con_iva"
+})
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "entity": { "name": "productos", "status": "published" },
+  "version": 3
+}
+```
+
+## MCP Tool: `list_entity_changes`
+
+**Profile:** advanced
+
+Lists the version history of an entity.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+
+## Auto-publishing
+
+When using `generate_entity` with `auto_publish: true`, the entity is created and published in a single step. Requires `version_message`.
+
+```
+generate_entity({
+  definition: { ... },
+  auto_publish: true,
+  version_message: "Version inicial"
+})
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/getting-started/concepts.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/getting-started/concepts.md
@@ -1,0 +1,77 @@
+# Key Concepts
+
+## Tenant
+
+A tenant is an isolated workspace. Each tenant has its own database schema, entities, rules, users, and configurations. Data between tenants is completely separated.
+
+- Each tenant has a unique **slug** (e.g., `mi-empresa`)
+- An admin can have access to multiple tenants
+- The active tenant is selected at the start of each MCP session
+
+## Entity
+
+An entity defines the data structure -- it is equivalent to a table. It has a name, fields, and configuration.
+
+**Lifecycle:**
+1. Created as a **draft**
+2. **Published** with a version message
+3. Each change creates a new draft that must be published
+
+Each entity has system fields (`id`, `created_at`, `updated_at`) and user-defined fields.
+
+## Field
+
+Fields define the columns of an entity.
+
+| Property | Description |
+|----------|-------------|
+| `name` | Display name (e.g., "Customer Name") |
+| `fieldKey` | Technical key (e.g., `nombre_cliente`) |
+| `fieldType` | Data type (see [Field Types](../entities/field-types.md)) |
+| `isRequired` | Whether it is required |
+| `isUnique` | Whether the value must be unique |
+| `config` | Type-specific configuration |
+
+**Available field types:** `text`, `textarea`, `number`, `email`, `phone`, `date`, `boolean`, `select`, `relation`, `file`, `location`.
+
+## Record
+
+A record is a row within an entity. The database structure is:
+
+```json
+{
+  "id": "uuid",
+  "entityId": "uuid",
+  "data": {
+    "nombre": "Juan Perez",
+    "email": "juan@example.com"
+  },
+  "createdAt": "2026-01-15T10:00:00Z",
+  "updatedAt": "2026-01-15T10:00:00Z"
+}
+```
+
+**Important:** Entity fields are inside `record.data`, not at the root of the record. Correct access: `record.data.email`.
+
+## Business Rule
+
+Rules automate logic over data. They are defined using a DSL (Domain Specific Language).
+
+**Types:**
+- **compute** -- Calculates fields automatically (e.g., `total = cantidad * precio`)
+- **validate** -- Validates data before saving (e.g., "the price must be positive")
+- **action** -- Executes side effects after saving (e.g., update a parent record)
+
+Rules also have a draft/published lifecycle.
+
+## Tool Profiles
+
+Fyso exposes MCP tools in three levels:
+
+| Profile | Count | Usage |
+|---------|-------|-------|
+| `core` | ~26 tools | For daily use -- create entities, CRUD, rules, deploy |
+| `advanced` | ~38 tools | Adds delete, test, flows, secrets, logs |
+| `all` | ~49 tools | Everything, including channels and bots |
+
+Configured via the `FYSO_TOOLS` environment variable (values: `core`, `advanced`, `all`). Default: `core`.

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/getting-started/mcp-setup.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/getting-started/mcp-setup.md
@@ -1,0 +1,59 @@
+# Configure MCP
+
+Fyso connects to AI agents through the MCP (Model Context Protocol) protocol.
+
+## Requirements
+
+- Node.js 18+
+- Fyso API key (obtained from the admin panel or the setup script)
+
+## Configuration in Claude Desktop
+
+Add the following configuration to your `claude_desktop_config.json` file:
+
+```json
+{
+  "mcpServers": {
+    "fyso": {
+      "command": "npx",
+      "args": ["-y", "@fyso/mcp-server"],
+      "env": {
+        "FYSO_API_KEY": "tu-api-key",
+        "FYSO_API_URL": "https://api.fyso.dev/api",
+        "FYSO_TOOLS": "core"
+      }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `FYSO_API_KEY` | Yes | API key for authentication |
+| `FYSO_API_URL` | Yes | Base URL of the API (e.g., `https://api.fyso.dev/api`) |
+| `FYSO_TOOLS` | No | Tool profile: `core` (default), `advanced`, `all` |
+
+## Verify Connection
+
+Once configured, the agent can verify the connection:
+
+```
+list_tenants()
+```
+
+It should return the list of accessible tenants.
+
+## Typical MCP Session Flow
+
+1. `list_tenants()` -- see available tenants
+2. `select_tenant({ tenantSlug: "mi-empresa" })` -- select context
+3. `list_entities()` -- see existing entities
+4. Work with entities, records, and rules
+
+All tools after `select_tenant` operate in the context of the selected tenant.
+
+## Tool Profiles
+
+See [Tool Profiles](../api/tool-profiles.md) for details on which tools each profile includes.

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/getting-started/quick-start.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/getting-started/quick-start.md
@@ -1,0 +1,86 @@
+# Quick Start
+
+Your first Fyso app in 5 minutes.
+
+## 1. Select a tenant
+
+Every workspace in Fyso is a **tenant**. The first step is to list and select one.
+
+**MCP:**
+```
+list_tenants()
+select_tenant({ tenantSlug: "mi-empresa" })
+```
+
+**Web panel:** It is selected automatically when you log in.
+
+## 2. Create an entity
+
+Entities are the tables of your app. Example: create a `clientes` entity.
+
+**MCP:**
+```
+generate_entity({
+  definition: {
+    entity: { name: "clientes", displayName: "Clientes" },
+    fields: [
+      { name: "Nombre", fieldKey: "nombre", fieldType: "text", isRequired: true },
+      { name: "Email", fieldKey: "email", fieldType: "email" },
+      { name: "Telefono", fieldKey: "telefono", fieldType: "phone" }
+    ]
+  },
+  auto_publish: true,
+  version_message: "Initial entity"
+})
+```
+
+## 3. Create records
+
+**MCP:**
+```
+create_record({
+  entityName: "clientes",
+  data: {
+    nombre: "Juan Perez",
+    email: "juan@example.com",
+    telefono: "+54 11 1234-5678"
+  }
+})
+```
+
+## 4. Query records
+
+**MCP:**
+```
+query_records({
+  entityName: "clientes",
+  filter: "nombre contains Juan",
+  limit: 10
+})
+```
+
+## 5. Add a business rule
+
+Example: validate that the email is required.
+
+**MCP:**
+```
+generate_business_rule({
+  entityName: "clientes",
+  dsl: {
+    type: "validate",
+    triggers: ["email"],
+    validate: [{
+      id: "email_requerido",
+      condition: "len(email) > 0",
+      message: "El email es obligatorio",
+      severity: "error"
+    }]
+  },
+  auto_publish: true
+})
+```
+
+## Next step
+
+Read [Concepts](concepts.md) to understand the Fyso architecture.

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -1,0 +1,30 @@
+# Fyso Documentation
+
+Fyso is a platform for building business applications using entities, business rules, and automations. It can be operated from a web panel or through MCP (Model Context Protocol) tools for AI agents.
+
+## Quick Start
+
+1. [Getting Started](getting-started/quick-start.md) -- Your first app in 5 minutes
+2. [Key Concepts](getting-started/concepts.md) -- Tenants, entities, fields, records, rules
+3. [Configure MCP](getting-started/mcp-setup.md) -- Connect AI agents to Fyso
+
+## Section by Section
+
+| Section | Description |
+|---------|-------------|
+| [Entities](entities/) | Create, configure, and publish entities |
+| [Records](records/) | CRUD, filters, relations, and semantic search |
+| [Business Rules](business-rules/) | Compute, validate, action -- full DSL |
+| [PDF](pdf/) | pdfme templates and document generation |
+| [Billing](billing/) | Free vs Pro plans, limits, Stripe |
+| [Deployment](deployment/) | Static sites, GitHub Actions |
+| [API](api/) | REST API, MCP reference, tool profiles |
+| [Scheduling](scheduling/) | Availability, bookings, schedules |
+| [Admin](admin/) | Users, roles, apps, import/export |
+
+## Audience
+
+This documentation serves two audiences:
+
+- **AI agents using MCP** -- Exact tool names, parameters, types, expected responses
+- **Humans using the web panel** -- Clear guides with examples and workflows

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/pdf/generation.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/pdf/generation.md
@@ -1,0 +1,75 @@
+# Generate PDFs
+
+## MCP Tool: `generate_pdf`
+
+**Profile:** core
+
+Generates a PDF by combining a template with data from a record.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `templateId` | string | Yes | ID of the record in `pdf_templates` |
+| `recordId` | string | No | ID of the record with the data |
+| `entityName` | string | Conditional | Entity name (required if using `recordId`) |
+| `data` | object | No | Additional or override data. Keys = template field names |
+| `store` | boolean | No | Save the PDF to storage. Default: true |
+| `updateField` | string | No | Record field where to save the PDF reference. Default: `pdf_documento` |
+
+### Generation Flow
+
+1. Finds the template by `templateId`
+2. If `recordId` is provided, fetches the record from the entity
+3. Maps the fields: the template `name` must match the record `fieldKey`
+4. If `data` is provided, it is merged (override) over the record data
+5. Generates the PDF
+6. If `store=true`, saves it to file storage
+7. If `updateField` is defined, updates that field of the record with the PDF link
+
+### Example: Invoice PDF
+
+```
+generate_pdf({
+  templateId: "uuid-de-la-plantilla",
+  recordId: "uuid-de-la-factura",
+  entityName: "facturas",
+  updateField: "pdf_documento"
+})
+```
+
+### Example: PDF with Custom Data
+
+```
+generate_pdf({
+  templateId: "uuid-de-la-plantilla",
+  data: {
+    empresa: "Mi Empresa S.A.",
+    fecha: "18/02/2026",
+    total: "$15,000.00"
+  }
+})
+```
+
+### Example: Record PDF with Extra Data
+
+```
+generate_pdf({
+  templateId: "uuid-de-la-plantilla",
+  recordId: "uuid-de-la-factura",
+  entityName: "facturas",
+  data: {
+    pie_pagina: "Gracias por su compra"
+  }
+})
+```
+
+### Response
+
+Returns the metadata of the generated file (URL, size, etc.) or the PDF in base64 if `store=false`.
+
+### Notes
+
+- Field names matter: the `name` in the template JSON must be exactly the same as the entity's `fieldKey`
+- Data in `data` overrides record data if both exist for the same field
+- For calculated fields or fixed text not in the record, use the `data` parameter

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/pdf/templates.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/pdf/templates.md
@@ -1,0 +1,117 @@
+# PDF Templates
+
+Fyso uses **pdfme** as the PDF generation engine. Templates define the document layout.
+
+## `pdf_templates` Entity
+
+The `pdf_templates` entity is created automatically the first time a PDF is generated. Each record is a template with these fields:
+
+| Field | Description |
+|-------|-------------|
+| `nombre` | Descriptive name of the template |
+| `template_json` | Layout in pdfme format (JSON) |
+| `entidad_origen` | Which entity the data comes from (e.g., `"facturas"`) |
+
+## template_json Format
+
+The `template_json` defines the page size and the fields with their positions:
+
+```json
+{
+  "basePdf": {
+    "width": 210,
+    "height": 297,
+    "padding": [20, 20, 20, 20]
+  },
+  "schemas": [
+    [
+      {
+        "name": "empresa",
+        "type": "text",
+        "position": { "x": 20, "y": 20 },
+        "width": 100,
+        "height": 12,
+        "fontSize": 20,
+        "fontWeight": "bold"
+      },
+      {
+        "name": "cliente_nombre",
+        "type": "text",
+        "position": { "x": 20, "y": 50 },
+        "width": 100,
+        "height": 8,
+        "fontSize": 12
+      },
+      {
+        "name": "fecha",
+        "type": "text",
+        "position": { "x": 150, "y": 20 },
+        "width": 40,
+        "height": 8,
+        "fontSize": 10,
+        "alignment": "right"
+      },
+      {
+        "name": "total",
+        "type": "text",
+        "position": { "x": 130, "y": 250 },
+        "width": 60,
+        "height": 12,
+        "fontSize": 16,
+        "fontWeight": "bold",
+        "alignment": "right"
+      }
+    ]
+  ]
+}
+```
+
+## Format Rules
+
+- Measurements are in **millimeters** (210x297 = A4)
+- `position.x` and `position.y`: coordinates from the top-left corner
+- The `name` of each field must match the **fieldKey** of the source entity
+- `schemas` is an array of pages -- each page is an array of fields
+- Available type: `text`
+
+## Field Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | string | Field name (must match fieldKey) |
+| `type` | string | Field type (`"text"`) |
+| `position` | object | `{ x: number, y: number }` in mm |
+| `width` | number | Field width in mm |
+| `height` | number | Field height in mm |
+| `fontSize` | number | Font size in pt |
+| `fontWeight` | string | `"bold"` or normal |
+| `fontColor` | string | Color in hex (e.g., `"#666666"`) |
+| `alignment` | string | `"left"`, `"center"`, `"right"` |
+
+## Multiple Pages
+
+Add more arrays inside `schemas`:
+
+```json
+{
+  "schemas": [
+    [ /* page 1 fields */ ],
+    [ /* page 2 fields */ ]
+  ]
+}
+```
+
+## Create Template via MCP
+
+```
+create_record({
+  entityName: "pdf_templates",
+  data: {
+    nombre: "Factura estandar",
+    entidad_origen: "facturas",
+    template_json: { /* pdfme layout */ }
+  }
+})
+```
+
+Or ask the agent: "Create a PDF template for invoices with fields: company, customer, items, total".

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/records/crud.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/records/crud.md
@@ -1,0 +1,221 @@
+# Record CRUD
+
+Basic operations on records: create, read, update, and delete.
+
+## Record Structure
+
+Entity fields are stored inside `data`:
+
+```json
+{
+  "id": "6bd2d1db-d104-4a15-977a-a759c38608a9",
+  "entityId": "79d376b6-b00d-4d07-83b6-62276bc57fee",
+  "name": "Test Company S.L.",
+  "data": {
+    "nombre": "Test Company S.L.",
+    "email": "test@company.com",
+    "phone": "+34 912345678"
+  },
+  "createdAt": "2026-02-03T12:51:15.352Z",
+  "updatedAt": "2026-02-03T12:51:15.352Z"
+}
+```
+
+**Important:** Access fields via `record.data.email`, NOT `record.email`.
+
+---
+
+## create_record
+
+**Profile:** core
+
+Creates a new record in an entity.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+| `data` | object | Yes | Record data (entity fields) |
+
+### Example
+
+```
+create_record({
+  entityName: "clientes",
+  data: {
+    nombre: "Maria Lopez",
+    email: "maria@example.com",
+    telefono: "+54 11 9876-5432",
+    estado: "activo"
+  }
+})
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "message": "Record created in clientes",
+  "record": {
+    "id": "uuid-del-registro",
+    "nombre": "Maria Lopez",
+    "email": "maria@example.com",
+    "telefono": "+54 11 9876-5432",
+    "estado": "activo"
+  }
+}
+```
+
+Use `get_entity_schema` first to know the required fields.
+
+---
+
+## query_records
+
+**Profile:** core
+
+Queries records from an entity with filters, pagination, sorting, and semantic search.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+| `filter` | string | No | Simple filter (see [Filters](filtering.md)) |
+| `limit` | number | No | Maximum records. Default: 50, max: 200 |
+| `offset` | number | No | Offset for pagination |
+| `orderBy` | string | No | Field to sort by |
+| `orderDir` | string | No | Direction: `"asc"` or `"desc"` |
+| `semantic` | string | No | Natural language semantic search |
+| `minSimilarity` | number | No | Similarity threshold (0-1) for semantic search |
+
+### Basic Example
+
+```
+query_records({
+  entityName: "clientes",
+  limit: 20,
+  orderBy: "nombre",
+  orderDir: "asc"
+})
+```
+
+### Example with Filter
+
+```
+query_records({
+  entityName: "clientes",
+  filter: "estado = activo",
+  limit: 10
+})
+```
+
+### Example with Semantic Search
+
+```
+query_records({
+  entityName: "productos",
+  semantic: "muebles de oficina modernos",
+  minSimilarity: 0.7,
+  limit: 5
+})
+```
+
+### Response
+
+```json
+{
+  "entityName": "clientes",
+  "total": 3,
+  "records": [
+    {
+      "id": "uuid",
+      "nombre": "Maria Lopez",
+      "email": "maria@example.com",
+      "estado": "activo"
+    }
+  ]
+}
+```
+
+For semantic search, each record includes a `similarity` field with the score.
+
+---
+
+## update_record
+
+**Profile:** core
+
+Updates an existing record. Only send the fields to modify (partial update).
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+| `recordId` | string | Yes | Record ID |
+| `data` | object | Yes | Fields to update |
+
+### Example
+
+```
+update_record({
+  entityName: "clientes",
+  recordId: "uuid-del-registro",
+  data: {
+    estado: "inactivo",
+    email: "maria.nueva@example.com"
+  }
+})
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "message": "Record uuid-del-registro updated",
+  "record": {
+    "id": "uuid-del-registro",
+    "nombre": "Maria Lopez",
+    "email": "maria.nueva@example.com",
+    "estado": "inactivo"
+  }
+}
+```
+
+---
+
+## delete_record
+
+**Profile:** core
+
+Deletes a record. This action cannot be undone.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `entityName` | string | Yes | Entity name |
+| `recordId` | string | Yes | Record ID |
+
+### Example
+
+```
+delete_record({
+  entityName: "clientes",
+  recordId: "uuid-del-registro"
+})
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "message": "Record uuid-del-registro deleted from clientes",
+  "deleted": true
+}
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/records/filtering.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/records/filtering.md
@@ -1,0 +1,66 @@
+# Filters
+
+Fyso supports simple filters in `query_records` and field-based filters in the REST API.
+
+## Filters in MCP (query_records)
+
+The `filter` parameter accepts an expression with the format:
+
+```
+field operator value
+```
+
+### Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `=` | Equals (case-insensitive) | `estado = activo` |
+| `!=` | Not equal | `estado != inactivo` |
+| `>` | Greater than (numeric) | `precio > 1000` |
+| `<` | Less than (numeric) | `stock < 10` |
+| `>=` | Greater than or equal | `total >= 500` |
+| `<=` | Less than or equal | `descuento <= 20` |
+| `contains` | Contains text (case-insensitive) | `nombre contains juan` |
+
+### Examples
+
+```
+query_records({ entityName: "productos", filter: "precio > 100" })
+query_records({ entityName: "clientes", filter: "nombre contains perez" })
+query_records({ entityName: "facturas", filter: "estado = pagada" })
+```
+
+### Notes
+
+- The filter is applied in memory after fetching the records (except for semantic search)
+- String values do not need quotes, but they are supported: `nombre = "Juan Perez"`
+- Numeric comparisons (`>`, `<`, `>=`, `<=`) convert values to numbers
+
+## Filters in REST API
+
+The REST API supports field-based filters using query parameters:
+
+```
+GET /api/entities/{entityName}/records?filter.estado=activo&filter.ciudad=buenos+aires
+```
+
+It also supports full-text search:
+
+```
+GET /api/entities/{entityName}/records?search=juan+perez
+```
+
+## Semantic Search
+
+Semantic search uses vectors to find records by meaning similarity, not by exact text match.
+
+```
+query_records({
+  entityName: "productos",
+  semantic: "algo para sentarse en la oficina",
+  minSimilarity: 0.6,
+  limit: 10
+})
+```
+
+When using `semantic`, the simple filter can be combined to post-filter the results.

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/records/relations.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/records/relations.md
@@ -1,0 +1,106 @@
+# Relations
+
+Relations connect records from different entities using `relation` type fields.
+
+## Create a Relation
+
+When defining a `relation` type field, the related entity is specified:
+
+```
+generate_entity({
+  definition: {
+    entity: { name: "facturas" },
+    fields: [
+      {
+        name: "Cliente",
+        fieldKey: "cliente_id",
+        fieldType: "relation",
+        config: { relatedEntity: "clientes" }
+      }
+    ]
+  }
+})
+```
+
+## Storage
+
+The relation field stores the UUID of the related record:
+
+```json
+{
+  "cliente_id": "6bd2d1db-d104-4a15-977a-a759c38608a9"
+}
+```
+
+## Resolving Relations
+
+When querying records, relations can be expanded with `resolve`:
+
+### MCP
+
+`query_records` resolves relations automatically (uses `resolve=true` internally).
+
+### REST API
+
+```
+GET /api/entities/facturas/records?resolve=true
+GET /api/entities/facturas/records/{id}?resolve=true
+```
+
+Without resolve, the field shows only the UUID. With resolve, it expands to the full object:
+
+**Without resolve:**
+```json
+{
+  "cliente_id": "6bd2d1db-..."
+}
+```
+
+**With resolve:**
+```json
+{
+  "cliente_id": {
+    "id": "6bd2d1db-...",
+    "data": {
+      "nombre": "Juan Perez",
+      "email": "juan@example.com"
+    }
+  }
+}
+```
+
+## Create Records with Relations
+
+When creating a record, pass the UUID of the related record:
+
+```
+create_record({
+  entityName: "facturas",
+  data: {
+    numero: "FAC-001",
+    cliente_id: "6bd2d1db-d104-4a15-977a-a759c38608a9",
+    fecha: "2026-02-18",
+    total: 1500
+  }
+})
+```
+
+## Relations in Business Rules
+
+Rules can use lookups to access data from related entities:
+
+```json
+{
+  "type": "compute",
+  "triggers": ["cliente_id"],
+  "compute": {
+    "cliente_nombre": {
+      "type": "lookup",
+      "entity": "clientes",
+      "matchField": "id",
+      "matchValue": "cliente_id",
+      "resultField": "nombre"
+    }
+  }
+}
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/scheduling/availability.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/scheduling/availability.md
@@ -1,0 +1,102 @@
+# Availability and Schedules
+
+Fyso's scheduling system calculates availability automatically from three entities.
+
+## Required Entities
+
+To use the scheduling system, the tenant must have these three entities:
+
+### `horarios`
+
+Defines the regular schedules for each professional.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `profesional_id` | relation | Reference to the professional |
+| `rrule` | text | Recurrence rule (RFC 5545 / RRule format) |
+| `hora_inicio` | text | Start time (HH:MM) |
+| `hora_fin` | text | End time (HH:MM) |
+| `duracion_turno` | number | Duration of each slot in minutes |
+| `activo` | boolean | Whether the schedule is active |
+
+Example `rrule`: `RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` (Monday to Friday).
+
+### `excepciones_horario`
+
+Defines exceptions to the regular schedule (holidays, special days).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `profesional_id` | relation | Reference to the professional |
+| `fecha` | date | Exception date (YYYY-MM-DD) |
+| `tipo` | select | `"bloqueado"` (unavailable) or `"horario_especial"` |
+| `hora_inicio` | text | Start time (only for `horario_especial`) |
+| `hora_fin` | text | End time (only for `horario_especial`) |
+
+### `turnos`
+
+The booked appointments.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `profesional_id` | relation | Reference to the professional |
+| `paciente_id` | relation | Reference to the patient/client |
+| `fecha` | date | Appointment date (YYYY-MM-DD) |
+| `hora` | text | Appointment time (HH:MM) |
+| `duracion` | number | Duration in minutes |
+| `estado` | select | `"confirmado"`, `"cancelado"`, etc. |
+| `notas` | textarea | Optional notes |
+
+## MCP Tool: `get_available_slots`
+
+**Profile:** core
+
+Calculates available slots considering schedules, exceptions, and existing appointments.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `profesional_id` | string | Yes | Professional's UUID |
+| `fecha` | string | No | Specific date (YYYY-MM-DD) |
+| `desde` | string | No | Range start (YYYY-MM-DD) |
+| `hasta` | string | No | Range end (YYYY-MM-DD, max 90 days) |
+
+Provide `fecha` for a single day, or `desde`/`hasta` for a range.
+
+### Example: Single Day
+
+```
+get_available_slots({
+  profesional_id: "uuid-del-profesional",
+  fecha: "2026-02-20"
+})
+```
+
+### Example: Date Range
+
+```
+get_available_slots({
+  profesional_id: "uuid-del-profesional",
+  desde: "2026-02-20",
+  hasta: "2026-02-28"
+})
+```
+
+### Response
+
+```json
+[
+  { "fecha": "2026-02-20", "hora": "09:00", "duracion": 30, "profesional_id": "uuid" },
+  { "fecha": "2026-02-20", "hora": "09:30", "duracion": 30, "profesional_id": "uuid" },
+  { "fecha": "2026-02-20", "hora": "10:00", "duracion": 30, "profesional_id": "uuid" }
+]
+```
+
+### Calculation Logic
+
+1. Gets the active schedules for the professional
+2. Generates slots based on `hora_inicio`, `hora_fin`, and `duracion_turno`
+3. Applies the recurrence rule (`rrule`) to determine which days it applies
+4. Excludes blocked dates and adjusts special schedules
+5. Excludes slots that already have a confirmed appointment

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/scheduling/bookings.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/scheduling/bookings.md
@@ -1,0 +1,87 @@
+# Bookings
+
+## MCP Tool: `create_booking`
+
+**Profile:** core
+
+Creates a booking after validating that the slot is available.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `profesional_id` | string | Yes | Professional's UUID |
+| `paciente_id` | string | Yes | Patient/client UUID |
+| `fecha` | string | Yes | Date (YYYY-MM-DD) |
+| `hora` | string | Yes | Time (HH:MM) |
+| `duracion` | number | No | Duration in minutes. Default: professional's slot duration |
+| `notas` | string | No | Optional notes |
+
+### Internal Flow
+
+1. Queries available slots for the date
+2. Verifies that `fecha + hora` is in the available slots list
+3. If available, creates a record in the `turnos` entity with `estado = "confirmado"`
+4. If not available, returns an error
+
+### Example
+
+```
+create_booking({
+  profesional_id: "uuid-del-profesional",
+  paciente_id: "uuid-del-paciente",
+  fecha: "2026-02-20",
+  hora: "10:00",
+  notas: "Control de rutina"
+})
+```
+
+### Successful Response
+
+```json
+{
+  "success": true,
+  "message": "Booking created for 2026-02-20 at 10:00",
+  "record": {
+    "id": "uuid-del-turno",
+    "profesional_id": "uuid",
+    "paciente_id": "uuid",
+    "fecha": "2026-02-20",
+    "hora": "10:00",
+    "duracion": 30,
+    "estado": "confirmado",
+    "notas": "Control de rutina"
+  }
+}
+```
+
+### Error: Slot Not Available
+
+```json
+{
+  "success": false,
+  "error": "Slot 2026-02-20 10:00 is not available for this professional"
+}
+```
+
+## Cancel an Appointment
+
+There is no dedicated tool for canceling. Update the record directly:
+
+```
+update_record({
+  entityName: "turnos",
+  recordId: "uuid-del-turno",
+  data: { estado: "cancelado" }
+})
+```
+
+## REST API
+
+The REST endpoint for availability:
+
+```
+GET /api/scheduling/available-slots?profesional_id=uuid&fecha=2026-02-20
+```
+
+Headers: `Authorization: Bearer TOKEN`


### PR DESCRIPTION
## Summary

Adds English translations for all documentation sections following the Docusaurus i18n format.

- 29 translated files covering all sections: getting-started, entities, records, business-rules, pdf, billing, deployment, api, scheduling, admin
- All code blocks and technical terms preserved as-is
- Translations placed in `site/i18n/en/docusaurus-plugin-content-docs/current/`
- Spanish remains the default locale

## Sections translated

- Getting Started (quick-start, concepts, mcp-setup)
- Entities (create, fields, field-types, publish)
- Records (CRUD, filtering, relations)
- Business Rules (overview, DSL reference, examples, execution logs)
- PDF (generation, templates)
- Billing (plans, stripe)
- Deployment (static sites, GitHub Actions)
- API (REST API, MCP tools reference, tool profiles)
- Scheduling (availability, bookings)
- Admin (users, apps, import/export)