### PR TITLE
feat: docs landing page with hero and section cards (#361)

### DIFF
--- a/site/i18n/en/code.json
+++ b/site/i18n/en/code.json
@@ -1,0 +1,65 @@
+{
+  "home.hero.subtitle": {
+    "message": "Build business apps with entities, rules, and AI. Operate from the web panel or MCP tools."
+  },
+  "home.hero.cta": {
+    "message": "Get Started"
+  },
+  "home.hero.mcp": {
+    "message": "Configure MCP"
+  },
+  "home.section.entities": {
+    "message": "Entities"
+  },
+  "home.section.entities.desc": {
+    "message": "Define your data model with fields, relations, and publish when ready."
+  },
+  "home.section.rules": {
+    "message": "Business Rules"
+  },
+  "home.section.rules.desc": {
+    "message": "Automate computations, validations, and actions with a simple DSL."
+  },
+  "home.section.api": {
+    "message": "REST API"
+  },
+  "home.section.api.desc": {
+    "message": "Auto-generated API for every entity. Auth via API key."
+  },
+  "home.section.scheduling": {
+    "message": "Scheduling"
+  },
+  "home.section.scheduling.desc": {
+    "message": "Availability slots, bookings, and calendar management."
+  },
+  "home.section.deploy": {
+    "message": "Deployment"
+  },
+  "home.section.deploy.desc": {
+    "message": "Deploy static sites to Fyso with GitHub Actions."
+  },
+  "home.section.pdf": {
+    "message": "PDF Generation"
+  },
+  "home.section.pdf.desc": {
+    "message": "Create templates with pdfme and generate documents from records."
+  },
+  "home.install.title": {
+    "message": "Connect AI agents in seconds"
+  },
+  "home.install.desc": {
+    "message": "Add Fyso as an MCP server to Claude, Cursor, or any MCP-compatible client."
+  },
+  "home.link.mcp": {
+    "message": "MCP Reference"
+  },
+  "home.link.billing": {
+    "message": "Plans & Limits"
+  },
+  "home.link.admin": {
+    "message": "Users & Roles"
+  },
+  "home.layout.title": {
+    "message": "Home"
+  }
+}

--- a/site/i18n/es/code.json
+++ b/site/i18n/es/code.json
@@ -1,0 +1,65 @@
+{
+  "home.hero.subtitle": {
+    "message": "Crea apps de negocio con entidades, reglas e IA. Opera desde el panel web o herramientas MCP."
+  },
+  "home.hero.cta": {
+    "message": "Empezar"
+  },
+  "home.hero.mcp": {
+    "message": "Configurar MCP"
+  },
+  "home.section.entities": {
+    "message": "Entidades"
+  },
+  "home.section.entities.desc": {
+    "message": "Define tu modelo de datos con campos, relaciones y publica cuando estes listo."
+  },
+  "home.section.rules": {
+    "message": "Reglas de negocio"
+  },
+  "home.section.rules.desc": {
+    "message": "Automatiza calculos, validaciones y acciones con un DSL simple."
+  },
+  "home.section.api": {
+    "message": "REST API"
+  },
+  "home.section.api.desc": {
+    "message": "API auto-generada para cada entidad. Autenticacion via API key."
+  },
+  "home.section.scheduling": {
+    "message": "Turnos"
+  },
+  "home.section.scheduling.desc": {
+    "message": "Slots de disponibilidad, reservas y gestion de horarios."
+  },
+  "home.section.deploy": {
+    "message": "Despliegue"
+  },
+  "home.section.deploy.desc": {
+    "message": "Despliega sites estaticos en Fyso con GitHub Actions."
+  },
+  "home.section.pdf": {
+    "message": "Generacion PDF"
+  },
+  "home.section.pdf.desc": {
+    "message": "Crea plantillas con pdfme y genera documentos desde registros."
+  },
+  "home.install.title": {
+    "message": "Conecta agentes de IA en segundos"
+  },
+  "home.install.desc": {
+    "message": "Anade Fyso como servidor MCP en Claude, Cursor o cualquier cliente compatible con MCP."
+  },
+  "home.link.mcp": {
+    "message": "Referencia MCP"
+  },
+  "home.link.billing": {
+    "message": "Planes y limites"
+  },
+  "home.link.admin": {
+    "message": "Usuarios y roles"
+  },
+  "home.layout.title": {
+    "message": "Inicio"
+  }
+}

--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -1,10 +1,9 @@
 /**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
+ * CSS modules for docs landing page.
  */
 
 .heroBanner {
-  padding: 4rem 0;
+  padding: 4rem 0 3rem;
   text-align: center;
   position: relative;
   overflow: hidden;
@@ -12,12 +11,170 @@
 
 @media screen and (max-width: 996px) {
   .heroBanner {
-    padding: 2rem;
+    padding: 2.5rem 1rem 2rem;
   }
+}
+
+.heroTitle {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin-bottom: 1rem;
+}
+
+@media screen and (max-width: 996px) {
+  .heroTitle {
+    font-size: 2rem;
+  }
+}
+
+.heroSubtitle {
+  font-size: 1.25rem;
+  color: rgba(255, 255, 255, 0.85);
+  max-width: 600px;
+  margin: 0 auto 2rem;
+  line-height: 1.6;
 }
 
 .buttons {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.sections {
+  padding: 3rem 0 4rem;
+}
+
+.sectionGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+@media screen and (max-width: 996px) {
+  .sectionGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .sectionGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--ifm-toc-border-color);
+  background: var(--ifm-background-surface-color);
+  transition: border-color 0.2s, box-shadow 0.2s;
+  text-decoration: none !important;
+  color: inherit !important;
+}
+
+.card:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 4px 12px rgba(108, 92, 231, 0.08);
+}
+
+.cardIcon {
+  font-size: 1.75rem;
+  margin-bottom: 0.75rem;
+  line-height: 1;
+}
+
+.cardTitle {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.375rem;
+  color: var(--ifm-font-color-base);
+}
+
+.cardDesc {
+  font-size: 0.875rem;
+  color: var(--ifm-font-color-secondary);
+  line-height: 1.5;
+  flex: 1;
+}
+
+.install {
+  padding: 3rem 0 4rem;
+  background: var(--ifm-background-surface-color);
+}
+
+.installInner {
+  max-width: 640px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.installTitle {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.installDesc {
+  font-size: 0.95rem;
+  color: var(--ifm-font-color-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.codeBlock {
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.875rem;
+  text-align: left;
+  overflow-x: auto;
+  line-height: 1.6;
+}
+
+[data-theme='dark'] .codeBlock {
+  background: #16181D;
+}
+
+.links {
+  padding: 2.5rem 0 3.5rem;
+}
+
+.linkGrid {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.linkItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--ifm-toc-border-color);
+  background: var(--ifm-background-surface-color);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ifm-font-color-base) !important;
+  text-decoration: none !important;
+  transition: border-color 0.2s;
+}
+
+.linkItem:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.linkIcon {
+  font-size: 1.1rem;
 }

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,26 +1,88 @@
 import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
+import Translate, {translate} from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
 
+const sections = [
+  {
+    icon: '🧩',
+    titleId: 'home.section.entities',
+    titleDefault: 'Entities',
+    descId: 'home.section.entities.desc',
+    descDefault: 'Define your data model with fields, relations, and publish when ready.',
+    link: '/docs/entities/create-entity',
+  },
+  {
+    icon: '⚙️',
+    titleId: 'home.section.rules',
+    titleDefault: 'Business Rules',
+    descId: 'home.section.rules.desc',
+    descDefault: 'Automate computations, validations, and actions with a simple DSL.',
+    link: '/docs/business-rules/overview',
+  },
+  {
+    icon: '🔌',
+    titleId: 'home.section.api',
+    titleDefault: 'REST API',
+    descId: 'home.section.api.desc',
+    descDefault: 'Auto-generated API for every entity. Auth via API key.',
+    link: '/docs/api/rest-api',
+  },
+  {
+    icon: '📅',
+    titleId: 'home.section.scheduling',
+    titleDefault: 'Scheduling',
+    descId: 'home.section.scheduling.desc',
+    descDefault: 'Availability slots, bookings, and calendar management.',
+    link: '/docs/scheduling/availability',
+  },
+  {
+    icon: '🚀',
+    titleId: 'home.section.deploy',
+    titleDefault: 'Deployment',
+    descId: 'home.section.deploy.desc',
+    descDefault: 'Deploy static sites to Fyso with GitHub Actions.',
+    link: '/docs/deployment/static-sites',
+  },
+  {
+    icon: '📄',
+    titleId: 'home.section.pdf',
+    titleDefault: 'PDF Generation',
+    descId: 'home.section.pdf.desc',
+    descDefault: 'Create templates with pdfme and generate documents from records.',
+    link: '/docs/pdf/templates',
+  },
+];
+
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        <Heading as="h1" className="hero__title">
+        <Heading as="h1" className={clsx('hero__title', styles.heroTitle)}>
           {siteConfig.title}
         </Heading>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <p className={styles.heroSubtitle}>
+          <Translate id="home.hero.subtitle">
+            Build business apps with entities, rules, and AI. Operate from the web panel or MCP tools.
+          </Translate>
+        </p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs">
-            Empezar
+            to="/docs/getting-started/quick-start">
+            <Translate id="home.hero.cta">Get Started</Translate>
+          </Link>
+          <Link
+            className="button button--secondary button--outline button--lg"
+            to="/docs/getting-started/mcp-setup"
+            style={{borderColor: 'rgba(255,255,255,0.4)', color: '#fff'}}>
+            <Translate id="home.hero.mcp">Configure MCP</Translate>
           </Link>
         </div>
       </div>
@@ -28,13 +90,89 @@ function HomepageHeader() {
   );
 }
 
+function SectionCards() {
+  return (
+    <section className={clsx('container', styles.sections)}>
+      <div className={styles.sectionGrid}>
+        {sections.map((s) => (
+          <Link key={s.titleId} to={s.link} className={styles.card}>
+            <div className={styles.cardIcon}>{s.icon}</div>
+            <div className={styles.cardTitle}>
+              <Translate id={s.titleId}>{s.titleDefault}</Translate>
+            </div>
+            <div className={styles.cardDesc}>
+              <Translate id={s.descId}>{s.descDefault}</Translate>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function InstallSnippet() {
+  return (
+    <section className={styles.install}>
+      <div className={clsx('container', styles.installInner)}>
+        <Heading as="h2" className={styles.installTitle}>
+          <Translate id="home.install.title">Connect AI agents in seconds</Translate>
+        </Heading>
+        <p className={styles.installDesc}>
+          <Translate id="home.install.desc">
+            Add Fyso as an MCP server to Claude, Cursor, or any MCP-compatible client.
+          </Translate>
+        </p>
+        <div className={styles.codeBlock}>
+          <code>
+            claude mcp add fyso https://mcp.fyso.dev/mcp \{'\n'}
+            {'  '}--header &quot;x-api-key: YOUR_API_KEY&quot;
+          </code>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ResourceLinks() {
+  return (
+    <section className={clsx('container', styles.links)}>
+      <div className={styles.linkGrid}>
+        <a
+          href="https://github.com/fyso-dev/docs"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.linkItem}>
+          <span className={styles.linkIcon}>📦</span>
+          GitHub
+        </a>
+        <Link to="/docs/api/mcp-tools" className={styles.linkItem}>
+          <span className={styles.linkIcon}>🤖</span>
+          <Translate id="home.link.mcp">MCP Reference</Translate>
+        </Link>
+        <Link to="/docs/billing/plans" className={styles.linkItem}>
+          <span className={styles.linkIcon}>💳</span>
+          <Translate id="home.link.billing">Plans & Limits</Translate>
+        </Link>
+        <Link to="/docs/admin/users" className={styles.linkItem}>
+          <span className={styles.linkIcon}>👤</span>
+          <Translate id="home.link.admin">Users & Roles</Translate>
+        </Link>
+      </div>
+    </section>
+  );
+}
+
 export default function Home(): ReactNode {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={siteConfig.title}
+      title={translate({id: 'home.layout.title', message: 'Home'})}
       description="Fyso documentation - Build business apps with AI">
       <HomepageHeader />
+      <main>
+        <SectionCards />
+        <InstallSnippet />
+        <ResourceLinks />
+      </main>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
Closes fyso-dev/fyso_backend#361

- Hero banner with violet gradient, tagline, and dual CTA buttons (Get Started + Configure MCP)
- 6 section cards in responsive grid (3/2/1 columns): Entities, Business Rules, REST API, Scheduling, Deployment, PDF Generation
- MCP installation snippet showing `claude mcp add` command
- Resource links row: GitHub, MCP Reference, Plans & Limits, Users & Roles
- Full bilingual support via Docusaurus `<Translate>` component with `i18n/en/code.json` and `i18n/es/code.json`
- CSS modules with dark mode support, matching the Fyso violet theme

## Test plan
- [ ] Verify landing page renders at `/` with hero, cards, snippet, and links
- [ ] Verify section cards link to correct doc pages
- [ ] Verify MCP snippet displays correctly in light and dark mode
- [ ] Verify locale switcher toggles between EN and ES on the landing page
- [ ] Verify responsive layout (3 cols desktop, 2 tablet, 1 mobile)