### PR TITLE
ci: auto-deploy docs on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy Docs
+
 on:
   push:
     branches: [main]
@@ -9,17 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: npm
           cache-dependency-path: site/package-lock.json
-      - run: cd site && npm ci
-      - run: cd site && npm run build
-      - name: Deploy to Fyso
+
+      - name: Install dependencies
+        run: cd site && npm ci
+
+      - name: Build
+        run: cd site && npm run build
+
+      - name: Deploy to docs.sites.fyso.dev
         run: |
-          cd site/build && zip -r ../../docs.zip .
-          cd ../..
-          curl -s -X POST "https://app.fyso.dev/api/sites/docs/deploy" \
-            -H "Authorization: Bearer ${{ secrets.FYSO_API_KEY }}" \
-            -F "file=@docs.zip"
+          cd site/build && zip -r ../../build.zip . && cd ../..
+          curl -sf -X POST https://app.fyso.dev/api/sites/docs/deploy \
+            -H "Authorization: Bearer ${{ secrets.FYSO_DEPLOY_TOKEN }}" \
+            -F "file=@build.zip"


### PR DESCRIPTION
Adds GitHub Actions workflow to build and deploy docs.sites.fyso.dev automatically on every push to main.

## Setup required

Add this secret to fyso-dev/docs (Settings > Secrets > Actions):
- Name: FYSO_DEPLOY_TOKEN
- Value: already configured by coordinator