### PR TITLE
docs: Unreleased — #524 #532 #533

### DIFF
--- a/site/docs/changelog.md
+++ b/site/docs/changelog.md
@@ -1,3 +1,16 @@
+## Unreleased
+
+### Features
+- **docs.fyso.dev** is now the official documentation URL. **fyso.dev** and **www.fyso.dev** serve the landing page, with a visible link to docs in Navbar and Footer. (#532)
+- **Dedicated instance `/health/detailed`** — returns extended isolation fields: `instance.id`, `instance.uptime_seconds`, `instance.region`, `database.type`, `security.network_isolation`, `security.public_db_access`. Allows verifying isolation status of Enterprise instances. (#524)
+- **Dedicated instance rollback** — `rollback.sh` script to revert to a previous image tag with health verification. (#524)
+- **Docker images on GHCR** — `fyso-api`, `fyso-mcp`, `fyso-migrate` automatically built and pushed to GHCR on pushes to `main` and semver tags. (#524)
+
+### Fixes
+- **Never-published draft entities visible via API** — `getEntityByName` now returns `null` for drafts without a `publishedVersion` when `includeDrafts=false`. Brand-new drafts (never published) no longer pass through the records API guard. (#533)
+
+---
+
 ## v1.14.0 — 2026-02-21
 
 ### Features

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
@@ -1,3 +1,16 @@
+## Sin publicar
+
+### Funcionalidades
+- **docs.fyso.dev** es ahora la URL oficial de la documentación. **fyso.dev** y **www.fyso.dev** sirven la landing page, con un link visible a docs en Navbar y Footer. (#532)
+- **Instancia dedicada `/health/detailed`** — devuelve campos extendidos de aislamiento: `instance.id`, `instance.uptime_seconds`, `instance.region`, `database.type`, `security.network_isolation`, `security.public_db_access`. Permite verificar el estado de aislamiento de instancias Enterprise. (#524)
+- **Rollback de instancia dedicada** — script `rollback.sh` para revertir a un tag de imagen anterior con verificación de salud. (#524)
+- **Imágenes Docker en GHCR** — `fyso-api`, `fyso-mcp`, `fyso-migrate` construidas y publicadas automáticamente en GHCR en cada push a `main` y en tags semver. (#524)
+
+### Correcciones
+- **Entidades draft nunca publicadas visibles vía API** — `getEntityByName` ahora retorna `null` para drafts sin `publishedVersion` cuando `includeDrafts=false`. Antes, una entidad recién creada (nunca publicada) pasaba el guard y era accesible por la API de registros. (#533)
+
+---
+
 ## v1.14.0 — 2026-02-21
 
 ### Funcionalidades


### PR DESCRIPTION
## Summary

Changelog entries for 3 PRs merged to develop on 2026-02-22.

**#532 feat** — docs.fyso.dev as official URL, fyso.dev as landing page  
**#524 feat** — Dedicated instance `/health/detailed` with isolation fields, rollback script, GHCR Docker build  
**#533 fix** — Brand-new draft entities no longer accessible via records API when `includeDrafts=false`

Both EN (`site/docs/changelog.md`) and ES (`site/i18n/es/...`) changelogs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)