### PR TITLE
docs: admin API keys + changelog for #543 #544 #545

### DIFF
--- a/site/docs/admin/api-keys.md
+++ b/site/docs/admin/api-keys.md
@@ -1,0 +1,151 @@
+# Admin API Keys
+
+Admin API keys (`fyso_adm_*`) allow programmatic access to platform-level administration endpoints. They are separate from tenant API keys and from super-admin session credentials.
+
+Use admin API keys to automate tenant provisioning, platform monitoring, or other administrative tasks from external systems.
+
+## Key Format
+
+Keys follow the format `fyso_adm_<48-char-hex>`. The full key is shown **only once** at creation time. Store it securely — it cannot be retrieved again.
+
+## Scopes
+
+Every key is created with one or more scopes that define what it can access:
+
+| Scope | Description |
+|-------|-------------|
+| `platform:read` | Read platform metadata and key listings |
+| `platform:write` | Create and revoke admin API keys |
+| `tenants:manage` | Create, modify, and delete tenants |
+
+## Authentication
+
+Include the key in one of two ways:
+
+```bash
+# Option 1: X-Admin-Key header
+curl -H "X-Admin-Key: fyso_adm_..." https://api.fyso.dev/api/admin/platform/keys
+
+# Option 2: Authorization header
+curl -H "Authorization: AdminKey fyso_adm_..." https://api.fyso.dev/api/admin/platform/keys
+```
+
+## Endpoints
+
+All endpoints require super-admin authentication in addition to a valid admin key scope.
+
+### List keys
+
+```bash
+GET /api/admin/platform/keys
+```
+
+Returns all active and revoked admin keys (key values are never returned, only prefixes).
+
+```bash
+curl -H "X-Admin-Key: fyso_adm_..." \
+  https://api.fyso.dev/api/admin/platform/keys
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "uuid",
+      "name": "CI Pipeline",
+      "keyPrefix": "fyso_adm_abc123",
+      "scopes": ["tenants:manage"],
+      "isActive": true,
+      "lastUsedAt": "2026-02-22T10:00:00Z",
+      "expiresAt": null,
+      "createdAt": "2026-02-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+### Create a key
+
+```bash
+POST /api/admin/platform/keys
+Content-Type: application/json
+
+{
+  "name": "CI Pipeline",
+  "scopes": ["tenants:manage"],
+  "expiresAt": "2027-01-01T00:00:00Z"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Human-readable label for the key |
+| `scopes` | string[] | Yes | One or more valid scopes |
+| `expiresAt` | ISO date | No | Expiration date. Omit for a non-expiring key |
+
+**Response** (key shown only once):
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "uuid",
+    "key": "fyso_adm_abc123...",
+    "keyPrefix": "fyso_adm_abc123",
+    "name": "CI Pipeline",
+    "scopes": ["tenants:manage"],
+    "expiresAt": "2027-01-01T00:00:00Z",
+    "createdAt": "2026-02-22T12:00:00Z"
+  }
+}
+```
+
+### Revoke a key
+
+```bash
+DELETE /api/admin/platform/keys/:id
+```
+
+Immediately deactivates the key. All subsequent requests using it return `401`.
+
+```bash
+curl -X DELETE -H "X-Admin-Key: fyso_adm_..." \
+  https://api.fyso.dev/api/admin/platform/keys/uuid
+```
+
+### Audit log
+
+```bash
+GET /api/admin/platform/keys/:id/audit?limit=100
+```
+
+Returns the usage history for a specific key: creation, every API call, and revocation. Maximum 500 entries per request.
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "action": "created",
+      "actorId": "admin-uuid",
+      "createdAt": "2026-02-01T00:00:00Z"
+    },
+    {
+      "action": "used",
+      "endpoint": "POST /api/admin/platform/keys",
+      "ip": "203.0.113.5",
+      "createdAt": "2026-02-22T10:00:00Z"
+    }
+  ]
+}
+```
+
+## Security Notes
+
+- Key values are hashed with bcrypt. The plaintext is never stored or re-exposed.
+- Expired keys are rejected at validation time even if still marked active.
+- Every creation, usage, and revocation is recorded in the audit log.
+- Prefix-based lookup (`fyso_adm_` + first 9 chars) narrows candidates before hash verification.

--- a/site/docs/changelog.md
+++ b/site/docs/changelog.md
@@ -1,12 +1,15 @@
 ## Unreleased
 
 ### Features
+- **Admin API keys** — Platform-level API keys (`fyso_adm_*`) with granular scope control (`platform:read`, `platform:write`, `tenants:manage`). Create, list, revoke, and audit keys via `GET/POST/DELETE /api/admin/platform/keys`. Full audit log with every creation, use, and revocation. Keys are bcrypt-hashed and shown only once at creation. (#543)
 - **docs.fyso.dev** is now the official documentation URL. **fyso.dev** and **www.fyso.dev** serve the landing page, with a visible link to docs in Navbar and Footer. (#532)
 - **Dedicated instance `/health/detailed`** — returns extended isolation fields: `instance.id`, `instance.uptime_seconds`, `instance.region`, `database.type`, `security.network_isolation`, `security.public_db_access`. Allows verifying isolation status of Enterprise instances. (#524)
 - **Dedicated instance rollback** — `rollback.sh` script to revert to a previous image tag with health verification. (#524)
 - **Docker images on GHCR** — `fyso-api`, `fyso-mcp`, `fyso-migrate` automatically built and pushed to GHCR on pushes to `main` and semver tags. (#524)
 
 ### Fixes
+- **Create record response now reflects after-save computed fields** — When an after-save business rule updates fields on the newly created record, the create response now returns the final state instead of the pre-rule snapshot. A subsequent GET would have shown the correct values; now the create response is consistent with it. (#544)
+- **Business rule evaluator concurrency limit** — Under heavy concurrent writes, rule evaluation could exhaust the database connection pool. A semaphore now caps concurrent rule evaluations (default: 8, configurable via `RULE_EVAL_MAX_CONCURRENCY` env var). Excess evaluations queue rather than spawning unbounded DB queries. (#545)
 - **Never-published draft entities visible via API** — `getEntityByName` now returns `null` for drafts without a `publishedVersion` when `includeDrafts=false`. Brand-new drafts (never published) no longer pass through the records API guard. (#533)
 
 ---

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/admin/api-keys.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/admin/api-keys.md
@@ -1,0 +1,151 @@
+# API Keys de Administración
+
+Las API keys de administración (`fyso_adm_*`) permiten acceso programático a los endpoints de administración de plataforma. Son independientes de las keys de tenant y de las credenciales de sesión super-admin.
+
+Usá las admin API keys para automatizar el aprovisionamiento de tenants, el monitoreo de plataforma u otras tareas administrativas desde sistemas externos.
+
+## Formato de las keys
+
+Las keys siguen el formato `fyso_adm_<48-char-hex>`. El valor completo se muestra **una sola vez** al crearla. Guardala de forma segura — no puede recuperarse después.
+
+## Scopes
+
+Cada key se crea con uno o más scopes que definen a qué puede acceder:
+
+| Scope | Descripción |
+|-------|-------------|
+| `platform:read` | Leer metadatos de plataforma y listados de keys |
+| `platform:write` | Crear y revocar admin API keys |
+| `tenants:manage` | Crear, modificar y eliminar tenants |
+
+## Autenticación
+
+Incluí la key de una de estas dos formas:
+
+```bash
+# Opción 1: header X-Admin-Key
+curl -H "X-Admin-Key: fyso_adm_..." https://api.fyso.dev/api/admin/platform/keys
+
+# Opción 2: header Authorization
+curl -H "Authorization: AdminKey fyso_adm_..." https://api.fyso.dev/api/admin/platform/keys
+```
+
+## Endpoints
+
+Todos los endpoints requieren autenticación super-admin además de un scope de admin key válido.
+
+### Listar keys
+
+```bash
+GET /api/admin/platform/keys
+```
+
+Devuelve todas las admin keys activas y revocadas (los valores de las keys nunca se devuelven, solo el prefijo).
+
+```bash
+curl -H "X-Admin-Key: fyso_adm_..." \
+  https://api.fyso.dev/api/admin/platform/keys
+```
+
+**Respuesta:**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "uuid",
+      "name": "CI Pipeline",
+      "keyPrefix": "fyso_adm_abc123",
+      "scopes": ["tenants:manage"],
+      "isActive": true,
+      "lastUsedAt": "2026-02-22T10:00:00Z",
+      "expiresAt": null,
+      "createdAt": "2026-02-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+### Crear una key
+
+```bash
+POST /api/admin/platform/keys
+Content-Type: application/json
+
+{
+  "name": "CI Pipeline",
+  "scopes": ["tenants:manage"],
+  "expiresAt": "2027-01-01T00:00:00Z"
+}
+```
+
+| Campo | Tipo | Requerido | Descripción |
+|-------|------|-----------|-------------|
+| `name` | string | Sí | Etiqueta legible para la key |
+| `scopes` | string[] | Sí | Uno o más scopes válidos |
+| `expiresAt` | fecha ISO | No | Fecha de expiración. Omitir para key sin vencimiento |
+
+**Respuesta** (key visible solo una vez):
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "uuid",
+    "key": "fyso_adm_abc123...",
+    "keyPrefix": "fyso_adm_abc123",
+    "name": "CI Pipeline",
+    "scopes": ["tenants:manage"],
+    "expiresAt": "2027-01-01T00:00:00Z",
+    "createdAt": "2026-02-22T12:00:00Z"
+  }
+}
+```
+
+### Revocar una key
+
+```bash
+DELETE /api/admin/platform/keys/:id
+```
+
+Desactiva la key de forma inmediata. Todas las requests posteriores que la usen devuelven `401`.
+
+```bash
+curl -X DELETE -H "X-Admin-Key: fyso_adm_..." \
+  https://api.fyso.dev/api/admin/platform/keys/uuid
+```
+
+### Log de auditoría
+
+```bash
+GET /api/admin/platform/keys/:id/audit?limit=100
+```
+
+Devuelve el historial de uso de una key: creación, cada llamada a la API y revocación. Máximo 500 entradas por request.
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "action": "created",
+      "actorId": "admin-uuid",
+      "createdAt": "2026-02-01T00:00:00Z"
+    },
+    {
+      "action": "used",
+      "endpoint": "POST /api/admin/platform/keys",
+      "ip": "203.0.113.5",
+      "createdAt": "2026-02-22T10:00:00Z"
+    }
+  ]
+}
+```
+
+## Seguridad
+
+- Los valores de las keys se hashean con bcrypt. El plaintext nunca se almacena ni se vuelve a exponer.
+- Las keys expiradas se rechazan en la validación aunque estén marcadas como activas.
+- Toda creación, uso y revocación queda registrada en el log de auditoría.
+- La búsqueda por prefijo (`fyso_adm_` + 9 chars) reduce candidatos antes de verificar el hash.

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
@@ -1,12 +1,15 @@
 ## Sin publicar
 
 ### Funcionalidades
+- **Admin API keys** — Keys de API a nivel de plataforma (`fyso_adm_*`) con control de scopes granular (`platform:read`, `platform:write`, `tenants:manage`). Crear, listar, revocar y auditar keys vía `GET/POST/DELETE /api/admin/platform/keys`. Log de auditoría completo con cada creación, uso y revocación. Las keys se hashean con bcrypt y se muestran solo una vez al crearlas. (#543)
 - **docs.fyso.dev** es ahora la URL oficial de la documentación. **fyso.dev** y **www.fyso.dev** sirven la landing page, con un link visible a docs en Navbar y Footer. (#532)
 - **Instancia dedicada `/health/detailed`** — devuelve campos extendidos de aislamiento: `instance.id`, `instance.uptime_seconds`, `instance.region`, `database.type`, `security.network_isolation`, `security.public_db_access`. Permite verificar el estado de aislamiento de instancias Enterprise. (#524)
 - **Rollback de instancia dedicada** — script `rollback.sh` para revertir a un tag de imagen anterior con verificación de salud. (#524)
 - **Imágenes Docker en GHCR** — `fyso-api`, `fyso-mcp`, `fyso-migrate` construidas y publicadas automáticamente en GHCR en cada push a `main` y en tags semver. (#524)
 
 ### Correcciones
+- **La respuesta de crear registro ahora refleja campos calculados por after-save** — Cuando una regla de negocio after-save actualiza campos del registro recién creado, la respuesta de create ahora devuelve el estado final en lugar del snapshot previo a la regla. Un GET posterior mostraba los valores correctos; ahora la respuesta de create es consistente. (#544)
+- **Límite de concurrencia en el evaluador de reglas de negocio** — Bajo alta concurrencia de escrituras, la evaluación de reglas podía agotar el pool de conexiones a la base de datos. Un semáforo limita ahora las evaluaciones concurrentes (por defecto: 8, configurable con la variable de entorno `RULE_EVAL_MAX_CONCURRENCY`). Las evaluaciones excedentes se encolan en lugar de generar queries ilimitadas. (#545)
 - **Entidades draft nunca publicadas visibles vía API** — `getEntityByName` ahora retorna `null` para drafts sin `publishedVersion` cuando `includeDrafts=false`. Antes, una entidad recién creada (nunca publicada) pasaba el guard y era accesible por la API de registros. (#533)
 
 ---


### PR DESCRIPTION
## Changes

### New pages
- `admin/api-keys.md` (EN + ES) — documents platform admin API keys (`fyso_adm_*`): scopes, authentication headers, REST endpoints (list, create, revoke, audit log), and security notes

### Changelog entries
- **#543** feat: Admin API keys with scope-based access control
- **#544** fix: Create record response now reflects after-save computed fields
- **#545** fix: Business rule evaluator concurrency limit (`RULE_EVAL_MAX_CONCURRENCY`)

## Source verified
- Routes: `packages/api/src/routes/admin-api-keys.ts`
- Middleware: `packages/api/src/middleware/admin-key-auth.ts`
- Service: `packages/api/src/services/admin-api-key.service.ts`