### PR TITLE
docs: webhooks guide + knowledge base update (issue #523)

### DIFF
--- a/site/docs/admin/knowledge.md
+++ b/site/docs/admin/knowledge.md
@@ -18,9 +18,20 @@ upload_document({
 })
 ```
 
-Supported formats: PDF, plain text (.txt), Markdown (.md).
+Supported formats: **PDF**, **HTML** (.html, .htm), **plain text** (.txt), **Markdown** (.md).
 
-After upload, the document is automatically chunked and indexed in the background.
+- PDF: text is extracted automatically before chunking.
+- HTML: tags are stripped, preserving text structure; `<script>`, `<style>`, and `<noscript>` blocks are skipped.
+- Text/Markdown: chunked and indexed directly.
+
+After upload, the document is automatically chunked and indexed in the background. Status transitions from `processing` → `ready`.
+
+### Plan limits
+
+| Plan | Documents | Storage |
+|------|-----------|---------|
+| Free | 10 | 5 MB |
+| Pro | 1,000 | 1 GB |
 
 ## Searching Documents
 
@@ -34,13 +45,43 @@ search_knowledge({
 })
 ```
 
-Returns matching chunks with source document, relevance score, and content excerpt.
+Returns matching chunks with source document, relevance score, and content excerpt. Every search is tracked for analytics (see [Stats](#stats)).
+
+**REST API:**
+
+```bash
+curl -X POST https://api.fyso.dev/api/knowledge/search \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": "How do I reset the device?", "limit": 5, "threshold": 0.7 }'
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "content": "To reset, hold the power button for 10 seconds...",
+        "score": 0.92,
+        "document": { "id": "...", "title": "Product Manual 2026", "source_type": "file" },
+        "chunk_index": 3
+      }
+    ],
+    "query_time_ms": 45
+  }
+}
+```
 
 ## Listing Documents
 
 **MCP Tool: `list_documents`** (Profile: core)
 
 Lists all documents in the tenant with metadata (title, upload date, chunk count, indexing status).
+
+Filter by status: `GET /api/knowledge/documents?status=ready`
 
 ## Getting a Document
 
@@ -50,17 +91,7 @@ Lists all documents in the tenant with metadata (title, upload date, chunk count
 get_document({ documentId: "uuid" })
 ```
 
-Returns document metadata and content.
-
-## Indexing Stats
-
-**MCP Tool: `get_knowledge_stats`** (Profile: core)
-
-Returns:
-- Total documents
-- Total chunks indexed
-- Embedding coverage (%)
-- Documents pending indexing
+Returns document metadata, content, and a preview of the first 5 chunks.
 
 ## Deleting Documents
 
@@ -71,6 +102,62 @@ delete_document({ documentId: "uuid" })
 ```
 
 Removes the document and all its indexed chunks.
+
+## Stats
+
+**MCP Tool: `get_knowledge_stats`** (Profile: core)
+
+Returns indexing statistics and search analytics:
+
+```bash
+GET /api/knowledge/stats
+```
+
+```json
+{
+  "documents": {
+    "total": 42,
+    "ready": 40,
+    "processing": 1,
+    "error": 1
+  },
+  "chunks": {
+    "total": 1820,
+    "avg_per_document": 43
+  },
+  "tokens": {
+    "total": 218400,
+    "avg_per_chunk": 120
+  },
+  "storage_bytes": 4718592,
+  "by_type": {
+    "application/pdf": 30,
+    "text/html": 10,
+    "text/plain": 2
+  },
+  "search": {
+    "total_queries_30d": 156,
+    "avg_latency_ms": 52,
+    "avg_score": 0.84,
+    "zero_result_rate": 0.06,
+    "coverage_score": 0.94
+  },
+  "top_documents": [
+    { "id": "...", "title": "Product Manual 2026", "hit_count": 48 }
+  ]
+}
+```
+
+`search` and `top_documents` are present when the events table is available. `zero_result_rate` is the fraction of queries that returned no results. `coverage_score` is the fraction that returned at least one result.
+
+## Dashboard
+
+From the admin panel, go to **Knowledge** in the sidebar to manage your knowledge base visually:
+
+- **Stats bar** — document count, storage used, total chunks
+- **Document list** — source type badge, status badge (ready/processing/error), created date, delete button
+- **Add document panel** — text tab (title + content) or URL tab (title + URL)
+- **Search panel** — enter a query, see results with relevance scores
 
 ## Use Cases
 

--- a/site/docs/admin/webhooks.md
+++ b/site/docs/admin/webhooks.md
@@ -1,0 +1,161 @@
+---
+sidebar_position: 5
+---
+
+# Webhooks
+
+Webhooks let you receive real-time HTTP notifications when records are created, updated, or deleted in any entity. Subscribe once, get notified automatically.
+
+## Event types
+
+| Event | When it fires |
+|-------|--------------|
+| `record.created` | A new record is created in the entity |
+| `record.updated` | A record is updated |
+| `record.deleted` | A record is deleted |
+
+## Creating a subscription
+
+**MCP Tool: `create_webhook`** (Profile: advanced)
+
+```
+create_webhook({
+  entity_name: "orders",
+  event_types: ["record.created", "record.updated"],
+  url: "https://your-server.com/webhooks/fyso",
+  secret: "your-signing-secret",
+  description: "Sync orders to ERP"
+})
+```
+
+**REST API:**
+
+```bash
+curl -X POST https://api.fyso.dev/api/webhooks/subscriptions \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "entity_name": "orders",
+    "event_types": ["record.created", "record.updated"],
+    "url": "https://your-server.com/webhooks/fyso",
+    "secret": "your-signing-secret",
+    "description": "Sync orders to ERP"
+  }'
+```
+
+Duplicate subscriptions (same entity + URL + events) return `409`.
+
+## Payload
+
+Every delivery POSTs a JSON body to your URL:
+
+```json
+{
+  "id": "evt_01HXYZ...",
+  "event": "record.created",
+  "entity": "orders",
+  "record_id": "rec_01HABC...",
+  "data": {
+    "id": "rec_01HABC...",
+    "customer_name": "Acme Corp",
+    "total": 1500,
+    "status": "pending"
+  },
+  "timestamp": "2026-02-23T14:32:00.000Z",
+  "tenant_id": "tenant_01HXY..."
+}
+```
+
+Your endpoint must return a `2xx` status within 30 seconds.
+
+## Verifying signatures
+
+When you set a `secret`, each request includes an `X-Fyso-Signature` header containing the HMAC-SHA256 hex digest of the raw JSON body.
+
+```typescript
+import { createHmac } from "crypto";
+
+function verifyWebhook(body: string, signature: string, secret: string): boolean {
+  const expected = createHmac("sha256", secret).update(body).digest("hex");
+  return expected === signature;
+}
+```
+
+Always verify signatures before processing payloads.
+
+## Listing subscriptions
+
+**MCP Tool: `list_webhooks`** (Profile: advanced)
+
+```
+list_webhooks()                         // all subscriptions
+list_webhooks({ entity_name: "orders" }) // filter by entity
+```
+
+**REST API:**
+
+```bash
+GET /api/webhooks/subscriptions
+GET /api/webhooks/subscriptions?entity=orders
+```
+
+## Updating a subscription
+
+```bash
+curl -X PUT https://api.fyso.dev/api/webhooks/subscriptions/<id> \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "is_active": false }'
+```
+
+Pass only the fields you want to change: `url`, `event_types`, `secret`, `is_active`, `description`.
+
+## Deleting a subscription
+
+**MCP Tool: `delete_webhook`** (Profile: advanced)
+
+```
+delete_webhook({ webhook_id: "sub_01HXYZ..." })
+```
+
+**REST API:**
+
+```bash
+DELETE /api/webhooks/subscriptions/<id>
+```
+
+## Delivery history
+
+Check the status of past deliveries for a subscription:
+
+```bash
+GET /api/webhooks/subscriptions/<id>/deliveries?limit=20
+```
+
+Each delivery shows:
+
+```json
+{
+  "id": "...",
+  "status": "delivered",
+  "http_status": 200,
+  "attempt_count": 1,
+  "created_at": "2026-02-23T14:32:00Z",
+  "completed_at": "2026-02-23T14:32:01Z"
+}
+```
+
+Status values: `pending`, `delivered`, `failed`.
+
+## Retries
+
+Failed deliveries (non-2xx or timeout) are retried up to **5 times** with exponential backoff. After all retries are exhausted the delivery is marked `failed`.
+
+## Admin dashboard
+
+From the admin panel, go to **Settings → Webhooks** to manage subscriptions visually:
+
+- Create subscriptions with entity selector, event checkboxes, URL input, and optional secret
+- Toggle active/inactive per subscription
+- View delivery history per subscription
+- Delete subscriptions with confirmation

--- a/site/docs/api/mcp-tools.md
+++ b/site/docs/api/mcp-tools.md
@@ -178,16 +178,26 @@ Configure which tools are exposed with the `FYSO_TOOLS` environment variable. Se
 
 ---
 
+## Webhooks
+
+| Tool | Profile | Description |
+|------|---------|-------------|
+| `create_webhook` | advanced | Subscribe to entity record events (created/updated/deleted) |
+| `list_webhooks` | advanced | List webhook subscriptions, optionally filtered by entity |
+| `delete_webhook` | advanced | Delete a webhook subscription |
+
+---
+
 ## Knowledge Base
 
 | Tool | Profile | Description |
 |------|---------|-------------|
-| `upload_document` | core | Upload document for RAG indexing (PDF, text, markdown) |
+| `upload_document` | core | Upload document for RAG indexing (PDF, HTML, text, markdown) |
 | `search_knowledge` | core | Semantic search across indexed documents |
 | `list_documents` | core | List uploaded documents |
 | `get_document` | core | Get document metadata and content |
 | `delete_document` | advanced | Delete a document from the knowledge base |
-| `get_knowledge_stats` | core | Get indexing stats (documents, chunks, embedding coverage) |
+| `get_knowledge_stats` | core | Get indexing stats and search analytics (30-day window) |
 
 ---
 

--- a/site/docs/api/tool-profiles.md
+++ b/site/docs/api/tool-profiles.md
@@ -18,9 +18,9 @@ Includes: tenant selection, entity management, records CRUD, business rules, RBA
 
 ### `advanced`
 
-Everything in `core` plus destructive operations, testing tools, flows, secrets, deploy tokens, and execution logs.
+Everything in `core` plus destructive operations, testing tools, flows, secrets, webhooks, deploy tokens, and execution logs.
 
-Adds: `delete_entity`, `delete_record`, `test_business_rule`, `delete_business_rule`, `get_rule_logs`, `delete_static_site`, `generate_deploy_token`, `set_secret`, `delete_secret`, `create_flow`, `list_flows`, `update_flow`, `delete_flow`, `toggle_flow`, `delete_document`, `tenant_login`, `manage_custom_fields`, `list_entity_changes`.
+Adds: `delete_entity`, `delete_record`, `test_business_rule`, `delete_business_rule`, `get_rule_logs`, `delete_static_site`, `generate_deploy_token`, `set_custom_domain`, `set_secret`, `delete_secret`, `create_flow`, `list_flows`, `update_flow`, `delete_flow`, `toggle_flow`, `create_webhook`, `list_webhooks`, `delete_webhook`, `delete_document`, `tenant_login`, `manage_custom_fields`, `list_entity_changes`.
 
 **~73 tools**
 

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/admin/knowledge.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/admin/knowledge.md
@@ -18,9 +18,20 @@ upload_document({
 })
 ```
 
-Formatos soportados: PDF, texto plano (.txt), Markdown (.md).
+Formatos soportados: **PDF**, **HTML** (.html, .htm), **texto plano** (.txt), **Markdown** (.md).
 
-Después de subir, el documento se divide en chunks e indexa automáticamente en segundo plano.
+- PDF: el texto se extrae automáticamente antes de dividirlo en chunks.
+- HTML: se eliminan las etiquetas preservando la estructura de texto; los bloques `<script>`, `<style>` y `<noscript>` se omiten.
+- Texto/Markdown: se divide en chunks e indexa directamente.
+
+Después de subir, el documento se procesa en segundo plano. El estado pasa de `processing` → `ready`.
+
+### Límites por plan
+
+| Plan | Documentos | Almacenamiento |
+|------|-----------|----------------|
+| Free | 10 | 5 MB |
+| Pro | 1,000 | 1 GB |
 
 ## Buscar documentos
 
@@ -34,13 +45,43 @@ search_knowledge({
 })
 ```
 
-Retorna chunks coincidentes con documento fuente, puntaje de relevancia y extracto de contenido.
+Retorna chunks coincidentes con documento fuente, puntaje de relevancia y extracto de contenido. Cada búsqueda se registra para analytics (ver [Estadísticas](#estadísticas)).
+
+**REST API:**
+
+```bash
+curl -X POST https://api.fyso.dev/api/knowledge/search \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": "¿Cómo reseteo el dispositivo?", "limit": 5, "threshold": 0.7 }'
+```
+
+Respuesta:
+
+```json
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "content": "Para resetear, mantené el botón de encendido por 10 segundos...",
+        "score": 0.92,
+        "document": { "id": "...", "title": "Manual de producto 2026", "source_type": "file" },
+        "chunk_index": 3
+      }
+    ],
+    "query_time_ms": 45
+  }
+}
+```
 
 ## Listar documentos
 
 **Herramienta MCP: `list_documents`** (Perfil: core)
 
 Lista todos los documentos del tenant con metadata (título, fecha de carga, cantidad de chunks, estado de indexación).
+
+Filtrar por estado: `GET /api/knowledge/documents?status=ready`
 
 ## Obtener un documento
 
@@ -50,17 +91,7 @@ Lista todos los documentos del tenant con metadata (título, fecha de carga, can
 get_document({ documentId: "uuid" })
 ```
 
-Retorna metadata y contenido del documento.
-
-## Estadísticas de indexación
-
-**Herramienta MCP: `get_knowledge_stats`** (Perfil: core)
-
-Retorna:
-- Total de documentos
-- Total de chunks indexados
-- Cobertura de embeddings (%)
-- Documentos pendientes de indexación
+Retorna metadata, contenido y un preview de los primeros 5 chunks.
 
 ## Eliminar documentos
 
@@ -71,6 +102,62 @@ delete_document({ documentId: "uuid" })
 ```
 
 Elimina el documento y todos sus chunks indexados.
+
+## Estadísticas
+
+**Herramienta MCP: `get_knowledge_stats`** (Perfil: core)
+
+Retorna estadísticas de indexación y analytics de búsqueda:
+
+```bash
+GET /api/knowledge/stats
+```
+
+```json
+{
+  "documents": {
+    "total": 42,
+    "ready": 40,
+    "processing": 1,
+    "error": 1
+  },
+  "chunks": {
+    "total": 1820,
+    "avg_per_document": 43
+  },
+  "tokens": {
+    "total": 218400,
+    "avg_per_chunk": 120
+  },
+  "storage_bytes": 4718592,
+  "by_type": {
+    "application/pdf": 30,
+    "text/html": 10,
+    "text/plain": 2
+  },
+  "search": {
+    "total_queries_30d": 156,
+    "avg_latency_ms": 52,
+    "avg_score": 0.84,
+    "zero_result_rate": 0.06,
+    "coverage_score": 0.94
+  },
+  "top_documents": [
+    { "id": "...", "title": "Manual de producto 2026", "hit_count": 48 }
+  ]
+}
+```
+
+`search` y `top_documents` están presentes cuando la tabla de eventos está disponible. `zero_result_rate` es la fracción de búsquedas que no devolvieron resultados. `coverage_score` es la fracción que devolvió al menos un resultado.
+
+## Panel de administración
+
+Desde el panel de admin, andá a **Conocimiento** en el menú lateral para gestionar tu base de conocimiento visualmente:
+
+- **Barra de estadísticas** — cantidad de documentos, almacenamiento usado, total de chunks
+- **Lista de documentos** — badge de tipo de fuente, badge de estado (ready/processing/error), fecha de carga, botón de eliminación
+- **Panel para agregar documentos** — tab de texto (título + contenido) o tab de URL (título + URL)
+- **Panel de búsqueda** — ingresá una consulta, mirá resultados con puntajes de relevancia
 
 ## Casos de uso
 

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/admin/webhooks.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/admin/webhooks.md
@@ -1,0 +1,161 @@
+---
+sidebar_position: 5
+---
+
+# Webhooks
+
+Los webhooks te permiten recibir notificaciones HTTP en tiempo real cuando se crean, actualizan o eliminan registros en cualquier entidad. Suscribite una vez, recibí notificaciones automáticamente.
+
+## Tipos de eventos
+
+| Evento | Cuándo se dispara |
+|--------|------------------|
+| `record.created` | Se crea un nuevo registro en la entidad |
+| `record.updated` | Se actualiza un registro |
+| `record.deleted` | Se elimina un registro |
+
+## Crear una suscripción
+
+**Herramienta MCP: `create_webhook`** (Perfil: advanced)
+
+```
+create_webhook({
+  entity_name: "pedidos",
+  event_types: ["record.created", "record.updated"],
+  url: "https://tu-servidor.com/webhooks/fyso",
+  secret: "tu-secreto-de-firma",
+  description: "Sincronizar pedidos con ERP"
+})
+```
+
+**REST API:**
+
+```bash
+curl -X POST https://api.fyso.dev/api/webhooks/subscriptions \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "entity_name": "pedidos",
+    "event_types": ["record.created", "record.updated"],
+    "url": "https://tu-servidor.com/webhooks/fyso",
+    "secret": "tu-secreto-de-firma",
+    "description": "Sincronizar pedidos con ERP"
+  }'
+```
+
+Las suscripciones duplicadas (misma entidad + URL + eventos) devuelven `409`.
+
+## Payload
+
+Cada entrega hace un POST JSON a tu URL:
+
+```json
+{
+  "id": "evt_01HXYZ...",
+  "event": "record.created",
+  "entity": "pedidos",
+  "record_id": "rec_01HABC...",
+  "data": {
+    "id": "rec_01HABC...",
+    "cliente": "Acme Corp",
+    "total": 1500,
+    "estado": "pendiente"
+  },
+  "timestamp": "2026-02-23T14:32:00.000Z",
+  "tenant_id": "tenant_01HXY..."
+}
+```
+
+Tu endpoint debe devolver un status `2xx` en menos de 30 segundos.
+
+## Verificar firmas
+
+Cuando configurás un `secret`, cada request incluye el header `X-Fyso-Signature` con el digest HMAC-SHA256 en hex del body JSON crudo.
+
+```typescript
+import { createHmac } from "crypto";
+
+function verificarWebhook(body: string, firma: string, secreto: string): boolean {
+  const esperado = createHmac("sha256", secreto).update(body).digest("hex");
+  return esperado === firma;
+}
+```
+
+Siempre verificá las firmas antes de procesar los payloads.
+
+## Listar suscripciones
+
+**Herramienta MCP: `list_webhooks`** (Perfil: advanced)
+
+```
+list_webhooks()                           // todas las suscripciones
+list_webhooks({ entity_name: "pedidos" }) // filtrar por entidad
+```
+
+**REST API:**
+
+```bash
+GET /api/webhooks/subscriptions
+GET /api/webhooks/subscriptions?entity=pedidos
+```
+
+## Actualizar una suscripción
+
+```bash
+curl -X PUT https://api.fyso.dev/api/webhooks/subscriptions/<id> \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "is_active": false }'
+```
+
+Pasá solo los campos que querés cambiar: `url`, `event_types`, `secret`, `is_active`, `description`.
+
+## Eliminar una suscripción
+
+**Herramienta MCP: `delete_webhook`** (Perfil: advanced)
+
+```
+delete_webhook({ webhook_id: "sub_01HXYZ..." })
+```
+
+**REST API:**
+
+```bash
+DELETE /api/webhooks/subscriptions/<id>
+```
+
+## Historial de entregas
+
+Consultá el estado de las entregas pasadas de una suscripción:
+
+```bash
+GET /api/webhooks/subscriptions/<id>/deliveries?limit=20
+```
+
+Cada entrega muestra:
+
+```json
+{
+  "id": "...",
+  "status": "delivered",
+  "http_status": 200,
+  "attempt_count": 1,
+  "created_at": "2026-02-23T14:32:00Z",
+  "completed_at": "2026-02-23T14:32:01Z"
+}
+```
+
+Valores de status: `pending`, `delivered`, `failed`.
+
+## Reintentos
+
+Las entregas fallidas (respuesta no-2xx o timeout) se reintentan hasta **5 veces** con backoff exponencial. Después de agotar los reintentos, la entrega se marca como `failed`.
+
+## Panel de administración
+
+Desde el panel de admin, andá a **Configuración → Webhooks** para gestionar suscripciones visualmente:
+
+- Crear suscripciones con selector de entidad, checkboxes de eventos, input de URL y secreto opcional
+- Activar/desactivar cada suscripción
+- Ver historial de entregas por suscripción
+- Eliminar suscripciones con confirmación

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/api/mcp-tools.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/api/mcp-tools.md
@@ -176,16 +176,26 @@ Configurá qué herramientas se exponen con la variable de entorno `FYSO_TOOLS`.
 
 ---
 
+## Webhooks
+
+| Herramienta | Perfil | Descripción |
+|-------------|--------|-------------|
+| `create_webhook` | advanced | Suscribirse a eventos de registros de una entidad (created/updated/deleted) |
+| `list_webhooks` | advanced | Listar suscripciones de webhooks, opcionalmente filtradas por entidad |
+| `delete_webhook` | advanced | Eliminar una suscripción de webhook |
+
+---
+
 ## Base de conocimiento
 
 | Herramienta | Perfil | Descripción |
 |-------------|--------|-------------|
-| `upload_document` | core | Subir documento para indexación RAG (PDF, texto, markdown) |
+| `upload_document` | core | Subir documento para indexación RAG (PDF, HTML, texto, markdown) |
 | `search_knowledge` | core | Búsqueda semántica en documentos indexados |
 | `list_documents` | core | Listar documentos subidos |
 | `get_document` | core | Obtener metadata y contenido de un documento |
 | `delete_document` | advanced | Eliminar un documento de la base de conocimiento |
-| `get_knowledge_stats` | core | Obtener estadísticas de indexación (documentos, chunks, cobertura de embeddings) |
+| `get_knowledge_stats` | core | Obtener estadísticas de indexación y analytics de búsqueda (ventana de 30 días) |
 
 ---
 

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/api/tool-profiles.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/api/tool-profiles.md
@@ -18,9 +18,9 @@ Incluye: selección de tenant, gestión de entidades, CRUD de registros, reglas 
 
 ### `advanced`
 
-Todo lo de `core` más operaciones destructivas, herramientas de testing, flows, secretos, tokens de deploy y logs de ejecución.
+Todo lo de `core` más operaciones destructivas, herramientas de testing, flows, secretos, webhooks, tokens de deploy y logs de ejecución.
 
-Agrega: `delete_entity`, `delete_record`, `test_business_rule`, `delete_business_rule`, `get_rule_logs`, `delete_static_site`, `generate_deploy_token`, `set_secret`, `delete_secret`, `create_flow`, `list_flows`, `update_flow`, `delete_flow`, `toggle_flow`, `delete_document`, `tenant_login`, `manage_custom_fields`, `list_entity_changes`.
+Agrega: `delete_entity`, `delete_record`, `test_business_rule`, `delete_business_rule`, `get_rule_logs`, `delete_static_site`, `generate_deploy_token`, `set_custom_domain`, `set_secret`, `delete_secret`, `create_flow`, `list_flows`, `update_flow`, `delete_flow`, `toggle_flow`, `create_webhook`, `list_webhooks`, `delete_webhook`, `delete_document`, `tenant_login`, `manage_custom_fields`, `list_entity_changes`.
 
 **~73 herramientas**
 


### PR DESCRIPTION
## Summary

Closes fyso-dev/fyso_backend#523. Adds missing documentation coverage for v1.13.0/v1.14.0 features.

- **New: `admin/webhooks.md`** — Full guide for webhook subscriptions: event types, MCP tools (advanced profile), REST API, payload structure, HMAC signature verification, delivery history, retries, admin dashboard. EN + ES. Refs #499.
- **Updated: `admin/knowledge.md`** — Add HTML as supported ingestion format (alongside PDF, text, markdown). Correct `get_knowledge_stats` response to match actual shape (chunks, tokens, by_type, search analytics 30d window, top_documents). Add plan limits table. Add dashboard management section. EN + ES. Refs #496, #497, #508.
- **Updated: `api/mcp-tools.md`** — New Webhooks section with `create_webhook`, `list_webhooks`, `delete_webhook`. Updated knowledge tool descriptions. EN + ES.
- **Updated: `api/tool-profiles.md`** — Add webhook tools and `set_custom_domain` to advanced profile "Adds" list (were missing). EN + ES.

Skipped: #503/#504 (landing page marketing), #506 (internal docs site infrastructure).

## Test plan

- [x] `npm run build` passes with no new errors
- [ ] Verify webhooks page renders correctly in preview
- [ ] Verify knowledge page shows updated stats structure