### PR TITLE
docs: entity views — ES translations (PR #735)

### DIFF
--- a/site/i18n/es/docusaurus-plugin-content-docs/current/api/mcp-tools.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/api/mcp-tools.md
@@ -59,6 +59,17 @@ Configurá qué herramientas se exponen con la variable de entorno `FYSO_TOOLS`.
 
 ---
 
+## Vistas
+
+| Herramienta | Perfil | Descripcion |
+|-------------|--------|-------------|
+| `create_view` | core | Crear una vista filtrada de entidad con permisos RBAC independientes |
+| `list_views` | core | Listar todas las vistas de entidades en el tenant |
+| `update_view` | core | Actualizar nombre, descripcion, filtro o estado activo de una vista |
+| `delete_view` | core | Eliminar una vista de entidad |
+
+---
+
 ## RBAC (Roles y permisos)
 
 | Herramienta | Perfil | Descripción |

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/api/rest-api.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/api/rest-api.md
@@ -120,6 +120,73 @@ Soporta actualizaciones parciales.
 DELETE /api/entities/{entityName}/records/{id}
 ```
 
+## Vistas
+
+Las vistas son proyecciones filtradas de entidades con permisos RBAC independientes. Ver [Vistas de entidades](/entities/views) para la guia completa.
+
+### Listar vistas
+
+```
+GET /api/views
+```
+
+Retorna todas las vistas. Admin ve todas; los usuarios de tenant solo ven las vistas en las que tienen permiso `view:<slug>` de lectura.
+
+### Crear vista
+
+```
+POST /api/views
+Content-Type: application/json
+
+{
+  "entitySlug": "tickets",
+  "slug": "mis-tickets",
+  "name": "Mis Tickets",
+  "description": "Tickets reportados por el usuario actual",
+  "filterDsl": {
+    "validate": [{ "condition": "reporter == $currentUser" }]
+  }
+}
+```
+
+Requiere acceso admin.
+
+### Actualizar vista
+
+```
+PUT /api/views/{slug}
+Content-Type: application/json
+
+{
+  "name": "Nombre actualizado",
+  "filterDsl": { "validate": [{ "condition": "status == 'open'" }] }
+}
+```
+
+### Eliminar vista
+
+```
+DELETE /api/views/{slug}
+```
+
+### Listar registros a traves de una vista
+
+```
+GET /api/views/{viewSlug}/records
+```
+
+Mismos parametros de query que el listado de registros de entidad (`page`, `limit`, `sort`, `order`, `search`, `resolve`, `filter.*`). El filtro base de la vista se aplica automaticamente y se compone con cualquier filtro adicional del query string.
+
+### Obtener un registro a traves de una vista
+
+```
+GET /api/views/{viewSlug}/records/{id}
+```
+
+Retorna `404` si el registro no coincide con el filtro de la vista.
+
+---
+
 ## Estructura del registro
 
 Los campos de la entidad estan dentro de `record.data`:

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
@@ -1,3 +1,16 @@
+## v1.21.0 — 2026-03-01
+
+### Funcionalidades
+- **Vistas de entidades — proyecciones filtradas con permisos RBAC** — Crea vistas con nombre sobre entidades usando condiciones en Filter DSL (ej: `reporter == $currentUser`). Cada vista tiene permisos RBAC independientes usando `view:<slug>` como clave de entidad. REST API: CRUD completo en `/api/views` mas acceso a registros en `/api/views/:slug/records`. Herramientas MCP: `create_view`, `list_views`, `update_view`, `delete_view`. Los filtros de vista se componen con los filtros del query string. El acceso admin omite filtros de usuario. 32 tests (10 integracion + 22 E2E cross-validation). (#735, closes #746)
+
+### Infraestructura
+- **Sitios estaticos: Cloudflare R2 + Worker** — El hosting de sitios estaticos migro de almacenamiento en filesystem a Cloudflare R2 servido por un Cloudflare Worker. Se elimino el endpoint `validate-domain`. (#731, closes #730)
+
+### Mantenimiento
+- **Eliminar referencias a PM2 y Caddy** — Se elimino el workflow de deploy con PM2, `ecosystem.config.js`, endpoints de health monitoring y targets de Caddy en el Makefile. Documentacion de deploy actualizada para la arquitectura actual de Lightsail + Cloudflare. (#736)
+
+---
+
 ## v1.20.0 — 2026-03-01
 
 ### Funcionalidades

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/entities/views.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/entities/views.md
@@ -1,0 +1,152 @@
+---
+sidebar_position: 5
+---
+
+# Vistas de entidades
+
+Una **vista** es una proyeccion filtrada con nombre de una entidad, con permisos RBAC propios. Las vistas permiten exponer un subconjunto de los registros de una entidad a roles especificos sin otorgar acceso a la entidad completa.
+
+## Caso de uso
+
+Una entidad `tickets` contiene todos los tickets de soporte. Quieres que los agentes de soporte solo vean sus propios tickets:
+
+1. Crea una vista `my-tickets` sobre la entidad `tickets` con filtro `reporter == $currentUser`
+2. Otorga al rol `agent` acceso de lectura a `view:my-tickets`
+3. Los agentes consultan `/api/views/my-tickets/records` y solo ven sus propios tickets
+
+Los administradores (acceso por API key) omiten el filtro y ven todos los registros a traves de la vista.
+
+## Crear una vista
+
+### Via MCP
+
+```
+create_view({
+  entitySlug: "tickets",
+  slug: "my-tickets",
+  name: "My Tickets",
+  description: "Tickets reportados por el usuario actual",
+  filterDsl: {
+    validate: [
+      { condition: "reporter == $currentUser" }
+    ]
+  }
+})
+```
+
+### Via REST API
+
+```bash
+curl -X POST "https://api.fyso.dev/api/views" \
+  -H "Authorization: Bearer API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "entitySlug": "tickets",
+    "slug": "my-tickets",
+    "name": "My Tickets",
+    "filterDsl": {
+      "validate": [{ "condition": "reporter == $currentUser" }]
+    }
+  }'
+```
+
+## Filter DSL
+
+Los filtros de vista usan la misma sintaxis que las reglas de negocio `on_query`:
+
+| Elemento | Ejemplos |
+|----------|----------|
+| Referencias a campos | `status`, `reporter`, `priority` |
+| Operadores | `==`, `!=`, `>`, `>=`, `<`, `<=` |
+| Variables | `$currentUser`, `$currentTenant` |
+| Operadores logicos | `and`, `or`, `not` |
+| Literales | `'active'`, `42` |
+| Agrupacion | `(status == 'open' or status == 'pending') and priority > 3` |
+
+El filtro se compila a una clausula SQL `WHERE` y se aplica del lado del servidor. Se compone con cualquier filtro adicional que el cliente pase en el query string.
+
+### Referencia de variables
+
+| Variable | Se resuelve a |
+|----------|--------------|
+| `$currentUser` | El ID del usuario autenticado del tenant |
+| `$currentTenant` | El ID del tenant actual |
+
+Cuando se accede via API key de admin (sin contexto de usuario), los filtros de vista que referencian `$currentUser` se omiten -- el admin ve todos los registros.
+
+## Permisos
+
+Las vistas usan el sistema RBAC con el formato de clave de entidad `view:<slug>`.
+
+Para otorgar acceso a un rol a una vista, incluye `view:<slug>` en los permisos de entidad del rol:
+
+```json
+{
+  "entities": {
+    "view:my-tickets": ["read"]
+  }
+}
+```
+
+- El acceso via API key de admin omite RBAC -- todas las vistas y registros son accesibles.
+- Los usuarios de tenant sin `read` en `view:<slug>` reciben `403 Forbidden`.
+- El permiso wildcard `*` de entidad tambien otorga acceso a todas las vistas.
+
+## Consultar registros a traves de una vista
+
+### Listar registros
+
+```
+GET /api/views/{viewSlug}/records
+```
+
+Soporta los mismos parametros de query que el listado de registros de entidad:
+
+| Parametro | Tipo | Default | Descripcion |
+|-----------|------|---------|-------------|
+| `page` | number | 1 | Numero de pagina |
+| `limit` | number | 20 | Items por pagina |
+| `sort` | string | - | Campo para ordenar |
+| `order` | string | `asc` | `asc` o `desc` |
+| `search` | string | - | Busqueda full-text |
+| `resolve` | boolean | false | Expandir relaciones |
+| `resolve_depth` | number | 1 | Profundidad de anidacion (max 3) |
+| `filter.{field}` | string | - | Filtro adicional por campo |
+
+Los filtros adicionales se componen con el filtro base de la vista (logica AND).
+
+### Obtener un registro
+
+```
+GET /api/views/{viewSlug}/records/{id}
+```
+
+Retorna un registro individual si coincide con el filtro de la vista. Retorna `404` si el registro existe pero no coincide con el filtro.
+
+## Administrar vistas
+
+Todas las operaciones de administracion requieren acceso admin (API key o rol admin).
+
+| Operacion | Herramienta MCP | Endpoint REST |
+|-----------|----------------|---------------|
+| Crear | `create_view` | `POST /api/views` |
+| Listar todas | `list_views` | `GET /api/views` |
+| Actualizar | `update_view` | `PUT /api/views/{slug}` |
+| Eliminar | `delete_view` | `DELETE /api/views/{slug}` |
+
+### Reglas de slug
+
+- Solo alfanumerico en minusculas con guiones: `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`
+- Maximo 100 caracteres
+- Debe ser unico entre todas las vistas del tenant
+
+### Campos actualizables
+
+| Campo | Tipo | Descripcion |
+|-------|------|-------------|
+| `name` | string | Nombre para mostrar |
+| `description` | string | Descripcion |
+| `filterDsl` | object | Nueva definicion de filtro |
+| `isActive` | boolean | Habilitar/deshabilitar la vista |
+
+Las vistas desactivadas (`isActive: false`) se excluyen de los resultados de listado y retornan `404` en consultas de registros.


### PR DESCRIPTION
## Summary
- Added v1.21.0 entry to ES changelog (entity views, R2 static sites, PM2/Caddy removal)
- Added Views section to ES REST API reference
- Added Views section to ES MCP tools reference
- Created full ES guide page at `entities/views.md`

EN docs were already complete from a prior commit. This PR adds the missing ES translations.

Triggered by: fyso-dev/fyso_backend#735

## Test plan
- [x] `npm run build` passes — no new broken links