### PR TITLE
docs: Base URL, static site auth, MCP vs REST

### DIFF
--- a/site/docs/agents/mcp-vs-rest.md
+++ b/site/docs/agents/mcp-vs-rest.md
@@ -1,0 +1,187 @@
+# MCP vs REST API
+
+Fyso offers two integration paths: **MCP** (Model Context Protocol) for AI agents, and a **REST API** for traditional HTTP clients. This guide compares both approaches.
+
+## When to Use Each
+
+| | MCP | REST API |
+|---|-----|----------|
+| **Best for** | AI agents (Claude, GPT, etc.) | Web apps, mobile apps, scripts, CI/CD |
+| **Auth setup** | Automatic (configured once in MCP client) | Manual headers on every request |
+| **Tenant context** | Auto-injected after `select_tenant` | Manual `X-Tenant-ID` header per request |
+| **Schema discovery** | `list_entities`, `get_entity_schema` tools | `GET /api/entities` endpoint |
+| **Streaming** | Supported natively | Standard HTTP responses |
+| **Batch operations** | Single tool call can handle complex workflows | One endpoint per operation |
+
+## Authentication Differences
+
+### MCP
+
+Authentication is configured once in the MCP client settings (e.g., Claude Desktop `claude_desktop_config.json`). After connecting, tenant context is set with a single tool call:
+
+```
+select_tenant("my-company-abc123")
+```
+
+All subsequent tool calls automatically include the tenant context and credentials. No manual headers needed.
+
+### REST API
+
+Every request must include authentication and tenant headers explicitly:
+
+```bash
+curl -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  "https://api.fyso.dev/api/entities/products/records"
+```
+
+See [REST API - Required Headers](/docs/api/rest-api#required-headers) for the full header reference.
+
+## Response Format Differences
+
+### Querying Records
+
+**MCP** (`query_records`) returns a flat list:
+
+```json
+{
+  "records": [
+    {
+      "id": "uuid-1",
+      "nombre": "Juan Perez",
+      "email": "juan@example.com",
+      "createdAt": "2026-02-03T12:51:15.352Z"
+    },
+    {
+      "id": "uuid-2",
+      "nombre": "Ana Lopez",
+      "email": "ana@example.com",
+      "createdAt": "2026-02-03T13:00:00.000Z"
+    }
+  ]
+}
+```
+
+**REST API** (`GET /api/entities/{entity}/records`) wraps results with pagination metadata:
+
+```json
+{
+  "success": true,
+  "data": {
+    "items": [
+      {
+        "id": "uuid-1",
+        "nombre": "Juan Perez",
+        "email": "juan@example.com",
+        "createdAt": "2026-02-03T12:51:15.352Z"
+      },
+      {
+        "id": "uuid-2",
+        "nombre": "Ana Lopez",
+        "email": "ana@example.com",
+        "createdAt": "2026-02-03T13:00:00.000Z"
+      }
+    ],
+    "total": 42,
+    "page": 1,
+    "limit": 20,
+    "totalPages": 3
+  }
+}
+```
+
+Key differences:
+- MCP uses `records` as the array key; REST uses `data.items`
+- REST includes pagination metadata (`total`, `page`, `limit`, `totalPages`)
+- Both return flat records (fields at the top level, no nested `.data` wrapper)
+
+### Creating a Record
+
+**MCP:**
+
+```
+create_record("products", { "nombre": "Widget", "precio": 29.99 })
+```
+
+```json
+{
+  "id": "uuid-new",
+  "nombre": "Widget",
+  "precio": 29.99,
+  "createdAt": "2026-03-01T10:00:00.000Z"
+}
+```
+
+**REST:**
+
+```bash
+curl -X POST -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  -H "Content-Type: application/json" \
+  -d '{"nombre": "Widget", "precio": 29.99}' \
+  "https://api.fyso.dev/api/entities/products/records"
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "uuid-new",
+    "nombre": "Widget",
+    "precio": 29.99,
+    "createdAt": "2026-03-01T10:00:00.000Z"
+  }
+}
+```
+
+## Side-by-Side Examples
+
+### List records with filter
+
+**MCP:**
+
+```
+query_records("tickets", filters: "status = open", limit: 10)
+```
+
+**REST:**
+
+```bash
+curl -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  "https://api.fyso.dev/api/entities/tickets/records?filter.status=open&limit=10"
+```
+
+### Update a record
+
+**MCP:**
+
+```
+update_record("tickets", "uuid-123", { "status": "closed" })
+```
+
+**REST:**
+
+```bash
+curl -X PUT -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "closed"}' \
+  "https://api.fyso.dev/api/entities/tickets/records/uuid-123"
+```
+
+### Delete a record
+
+**MCP:**
+
+```
+delete_record("tickets", "uuid-123")
+```
+
+**REST:**
+
+```bash
+curl -X DELETE -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  "https://api.fyso.dev/api/entities/tickets/records/uuid-123"
+```

--- a/site/docs/agents/static-site-auth.md
+++ b/site/docs/agents/static-site-auth.md
@@ -1,0 +1,132 @@
+# Auth for Static Sites
+
+This guide covers authentication strategies for static sites deployed on Fyso. Choose the method that fits your use case.
+
+## Public Keys (`fyso_pk_*`)
+
+Best for **public-facing read-only** content like dashboards, directories, or catalogs.
+
+Public keys are created via the MCP `create_record` tool on the `_fyso_api_keys` entity or through the admin UI. They support:
+
+- Configurable TTL (up to 365 days)
+- RBAC scoping per entity and operation
+- Rate limiting
+- CORS origin restrictions
+- Field-level read/write permissions
+
+```bash
+curl -H "Authorization: Bearer fyso_pk_abc123..." \
+  -H "X-Tenant-ID: my-company-abc123" \
+  "https://api.fyso.dev/api/entities/products/records"
+```
+
+Public keys do **not** require user login. They are ideal for pages that display data without user interaction.
+
+## Dynamic Login
+
+Best for **authenticated experiences** where each user sees personalized data.
+
+The flow:
+1. User enters credentials in your static site
+2. Your JS calls `POST /api/auth/tenant/login` to get a JWT
+3. Use the JWT for subsequent API calls
+
+### Complete Example
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>My Fyso App</title>
+</head>
+<body>
+  <div id="login-form">
+    <h2>Login</h2>
+    <input type="email" id="email" placeholder="Email" />
+    <input type="password" id="password" placeholder="Password" />
+    <button onclick="login()">Login</button>
+  </div>
+
+  <div id="app" style="display:none">
+    <h2>Records</h2>
+    <ul id="record-list"></ul>
+  </div>
+
+  <script>
+    const TENANT_ID = 'my-company-abc123';
+    const BASE_URL = 'https://api.fyso.dev/api';
+    let token = null;
+
+    async function login() {
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+
+      const res = await fetch(`${BASE_URL}/auth/tenant/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Tenant-ID': TENANT_ID,
+        },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const json = await res.json();
+      if (json.success) {
+        token = json.data.token;
+        document.getElementById('login-form').style.display = 'none';
+        document.getElementById('app').style.display = 'block';
+        loadRecords();
+      } else {
+        alert('Login failed: ' + (json.error?.message || 'Unknown error'));
+      }
+    }
+
+    async function loadRecords() {
+      const res = await fetch(`${BASE_URL}/entities/products/records`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'X-Tenant-ID': TENANT_ID,
+        },
+      });
+
+      const json = await res.json();
+      const list = document.getElementById('record-list');
+      list.innerHTML = '';
+
+      for (const record of json.data.items) {
+        const li = document.createElement('li');
+        li.textContent = record.name || record.id;
+        list.appendChild(li);
+      }
+    }
+  </script>
+</body>
+</html>
+```
+
+## Temporary Tokens
+
+For **demos and quick tests only**. You can manually generate a JWT via the MCP `tenant_login` tool and hardcode it in your static site.
+
+```javascript
+// WARNING: Token will expire. Do NOT use in production.
+const TEMP_TOKEN = 'eyJhbGciOiJIUzI1NiIs...';
+
+fetch('https://api.fyso.dev/api/entities/products/records', {
+  headers: {
+    'Authorization': `Bearer ${TEMP_TOKEN}`,
+    'X-Tenant-ID': 'my-company-abc123',
+  },
+});
+```
+
+> **Warning:** JWTs expire (default 24h). Hardcoded tokens will stop working after expiration. Use public keys or dynamic login for anything beyond a quick test.
+
+## Choosing the Right Method
+
+| Method | Auth required | TTL | Best for |
+|--------|--------------|-----|----------|
+| Public Key (`fyso_pk_*`) | No | Up to 365 days | Public dashboards, catalogs, read-only pages |
+| Dynamic Login | Yes (per user) | JWT expiry (~24h) | User-specific data, interactive apps |
+| Temporary Token | No | JWT expiry (~24h) | Quick demos and development tests |

--- a/site/docs/api/rest-api.md
+++ b/site/docs/api/rest-api.md
@@ -2,6 +2,16 @@
 
 Fyso exposes a REST API for external access to tenant data.
 
+## Base URL
+
+All API requests use a single centralized host:
+
+```
+https://api.fyso.dev/api
+```
+
+> **Important:** Do NOT use tenant subdomains (e.g., `my-tenant.fyso.dev`) for API calls. The API is centralized — tenant isolation is handled via the `X-Tenant-ID` header.
+
 ## Authentication
 
 Two available methods:
@@ -20,6 +30,7 @@ curl -X POST "https://api.fyso.dev/api/auth/tenant/login" \
 
 # 2. Use the token
 curl -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: mi-empresa" \
   "https://api.fyso.dev/api/entities/clientes/records"
 ```
 
@@ -27,12 +38,22 @@ curl -H "Authorization: Bearer JWT_TOKEN" \
 
 ```bash
 curl -H "Authorization: Bearer API_KEY" \
+  -H "X-Tenant-ID: my-company-abc123" \
   "https://api.fyso.dev/api/entities/clientes/records"
 
 # Or alternative:
 curl -H "X-API-Key: API_KEY" \
+  -H "X-Tenant-ID: my-company-abc123" \
   "https://api.fyso.dev/api/entities/clientes/records"
 ```
+
+### Required Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| Authorization | Yes | `Bearer {JWT}` or `Bearer {API_KEY}` or `Bearer {fyso_pk_*}` |
+| X-Tenant-ID | Yes | Tenant slug (e.g., `my-company-abc123`) |
+| Content-Type | Yes (POST/PUT) | `application/json` |
 
 ## CRUD Endpoints
 
@@ -40,6 +61,12 @@ curl -H "X-API-Key: API_KEY" \
 
 ```
 GET /api/entities/{entityName}/records
+```
+
+```bash
+curl -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  "https://api.fyso.dev/api/entities/clientes/records?page=1&limit=20"
 ```
 
 **Query params:**
@@ -60,15 +87,12 @@ GET /api/entities/{entityName}/records
 {
   "success": true,
   "data": {
-    "data": [
+    "items": [
       {
         "id": "uuid",
         "entityId": "uuid",
-        "name": "Juan Perez",
-        "data": {
-          "nombre": "Juan Perez",
-          "email": "juan@example.com"
-        },
+        "nombre": "Juan Perez",
+        "email": "juan@example.com",
         "createdAt": "2026-02-03T12:51:15.352Z",
         "updatedAt": "2026-02-03T12:51:15.352Z"
       }
@@ -87,29 +111,40 @@ GET /api/entities/{entityName}/records
 GET /api/entities/{entityName}/records/{id}
 ```
 
+```bash
+curl -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  "https://api.fyso.dev/api/entities/clientes/records/{id}"
+```
+
 **Query params:** `resolve` (boolean)
 
 ### Create a Record
 
 ```
 POST /api/entities/{entityName}/records
-Content-Type: application/json
+```
 
-{
-  "nombre": "Juan Perez",
-  "email": "juan@example.com"
-}
+```bash
+curl -X POST -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  -H "Content-Type: application/json" \
+  -d '{"nombre": "Juan Perez", "email": "juan@example.com"}' \
+  "https://api.fyso.dev/api/entities/clientes/records"
 ```
 
 ### Update a Record
 
 ```
 PUT /api/entities/{entityName}/records/{id}
-Content-Type: application/json
+```
 
-{
-  "email": "juan.nuevo@example.com"
-}
+```bash
+curl -X PUT -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "juan.nuevo@example.com"}' \
+  "https://api.fyso.dev/api/entities/clientes/records/{id}"
 ```
 
 Supports partial updates.
@@ -118,6 +153,12 @@ Supports partial updates.
 
 ```
 DELETE /api/entities/{entityName}/records/{id}
+```
+
+```bash
+curl -X DELETE -H "Authorization: Bearer JWT_TOKEN" \
+  -H "X-Tenant-ID: my-company-abc123" \
+  "https://api.fyso.dev/api/entities/clientes/records/{id}"
 ```
 
 ## Views
@@ -189,11 +230,11 @@ Returns `404` if the record does not match the view's filter.
 
 ## Record Structure
 
-Entity fields are inside `record.data`:
+Entity fields are at the top level of the record object:
 
 ```
-record.data.email     -- CORRECT
-record.email          -- INCORRECT
+record.email          -- CORRECT
+record.nombre         -- CORRECT
 ```
 
 ## Error Codes

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -6,6 +6,8 @@
 
 - Always use `select_tenant` before any tenant-specific operation.
 - Use MCP tools (not REST) when building from an AI agent — MCP handles auth and tenant context automatically.
+- REST API base URL: `https://api.fyso.dev/api` — do NOT use tenant subdomains. Tenant isolation is handled via the `X-Tenant-ID` header.
+- Every REST API request requires `Authorization` and `X-Tenant-ID` headers.
 - Never create entities with fields that duplicate system fields (id, createdAt, updatedAt).
 - Use `generate_entity` with `auto_publish: true` for quick prototyping. Use the draft/publish cycle for production.
 - Use `generate_business_rule` with a natural language prompt instead of writing DSL manually — the server generates and validates the DSL.
@@ -24,6 +26,8 @@
 - [Users & RBAC](https://docs.fyso.dev/docs/agents/users-and-rbac): Roles, custom roles, entity permissions, row-level filtering, invitations
 - [Channel Tools](https://docs.fyso.dev/docs/agents/channel-tools): Custom MCP tools, Tool DSL, bot identity, cross-tenant tool execution
 - [Embeddings & Semantic Search](https://docs.fyso.dev/docs/agents/embeddings): Record embeddings (field-level vectors), grouped embeddings, TTL, Knowledge Base RAG, semantic search via MCP and REST, DSL semantic_search operation, admin stats and reindex
+- [Auth for Static Sites](https://docs.fyso.dev/docs/agents/static-site-auth): Public keys (fyso_pk_*), dynamic login flow, temporary tokens, complete HTML+JS example
+- [MCP vs REST API](https://docs.fyso.dev/docs/agents/mcp-vs-rest): When to use each, auth differences, response format comparison, side-by-side examples
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- **#29**: Added `## Base URL` section and `### Required Headers` table to REST API docs. Added `X-Tenant-ID` header to all CRUD curl examples. Updated response format to use flat records with `items` array.
- **#30**: Created `agents/static-site-auth.md` covering public keys (`fyso_pk_*`), dynamic login flow with complete HTML+JS example, and temporary tokens with expiration warnings.
- **#31**: Created `agents/mcp-vs-rest.md` with auth handling differences, response format comparison (MCP flat `records` vs REST `data.items` with pagination), and side-by-side code examples for all CRUD operations.
- Updated `llms.txt` with base URL info and links to new pages.

Closes #29
Closes #30
Closes #31