### PR TITLE
docs: Claude Code plugin page and MCP setup update

### DIFF
--- a/site/docs/getting-started/claude-plugin.md
+++ b/site/docs/getting-started/claude-plugin.md
@@ -1,0 +1,137 @@
+---
+sidebar_position: 4
+---
+
+# Claude Code Plugin
+
+The `@fyso/claude-plugin` package installs the full Fyso development experience into Claude Code: skills, hooks, and MCP server connection — in one command.
+
+## What it includes
+
+| Component | Description |
+|-----------|-------------|
+| Skills | 19 slash commands (`/fyso-plan`, `/fyso-build`, `/fyso-verify`, `/fyso-ui`, and more) |
+| Hooks | `PostToolUse` hook that auto-syncs `FYSO-REFERENCE.md` when reference files change |
+| MCP server | Connects Claude Code to `https://app.fyso.dev/mcp` via OAuth |
+| Reference docs | `FYSO-REFERENCE.md` — consolidated API and DSL reference, always loaded |
+
+## Installation
+
+```bash
+bunx @fyso/claude-plugin install
+```
+
+That command:
+1. Symlinks each skill into `~/.claude/skills/`
+2. Merges the sync hook into `~/.claude/settings.json`
+3. Copies `FYSO-REFERENCE.md` into `~/.claude/`
+
+Restart Claude Code after install.
+
+### Alternative install methods
+
+```bash
+# From a local clone of the fyso repo
+bun packages/claude-plugin/bin/cli.ts install
+
+# Silent mode (runs automatically via postinstall)
+bunx @fyso/claude-plugin install --auto
+```
+
+## Authentication
+
+The plugin connects to Fyso via OAuth — no API key needed.
+
+When Claude Code first calls a Fyso MCP tool, `mcp-remote` will open a browser window for you to sign in to your Fyso account. The session token is stored locally and reused on subsequent runs.
+
+The `.mcp.json` the plugin registers looks like this:
+
+```json
+{
+  "mcpServers": {
+    "fyso": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://app.fyso.dev/mcp"]
+    }
+  }
+}
+```
+
+No environment variables are required.
+
+## CLI commands
+
+```bash
+fyso-plugin install      # Install skills, hooks, and reference docs
+fyso-plugin uninstall    # Remove installed skills
+fyso-plugin status       # Show what is installed
+fyso-plugin sync         # Regenerate FYSO-REFERENCE.md from source files
+fyso-plugin help         # Show usage
+```
+
+All commands can also be run with `bunx @fyso/claude-plugin <command>`.
+
+## Verify the install
+
+```bash
+fyso-plugin status
+```
+
+Expected output (green dots = installed):
+
+```
+Skills:
+  ● /fyso-plan   (symlink)
+  ● /fyso-build  (symlink)
+  ...
+
+Hooks:
+  ● PostToolUse: sync-reference hook
+
+Reference:
+  ● FYSO-REFERENCE.md
+```
+
+## Uninstall
+
+```bash
+fyso-plugin uninstall
+```
+
+Removes all skill symlinks from `~/.claude/skills/`. The hook in `settings.json` and `FYSO-REFERENCE.md` are left in place — remove them manually if needed.
+
+## Plugin manifest fields
+
+The `.claude-plugin/plugin.json` manifest declares:
+
+| Field | Value |
+|-------|-------|
+| `skills` | `./skills/` |
+| `hooks` | `./hooks/hooks.json` |
+| `mcpServers` | `./.mcp.json` |
+
+The `agents` field is not used — agents are referenced by skills at runtime, not installed as separate components.
+
+## Troubleshooting
+
+**Skills not showing up after install**
+
+Restart Claude Code. Skill discovery runs at startup.
+
+**OAuth browser window does not open**
+
+Make sure `npx` is available in your PATH and that `mcp-remote` can resolve `https://app.fyso.dev/mcp`. Run the connection once manually:
+
+```bash
+npx -y mcp-remote https://app.fyso.dev/mcp
+```
+
+**`FYSO_API_KEY` errors**
+
+The plugin no longer uses `FYSO_API_KEY`. If you see this error, you may have an older version of the plugin. Re-install with `bunx @fyso/claude-plugin install`.
+
+**Reference out of date**
+
+```bash
+fyso-plugin sync
+```

--- a/site/docs/getting-started/mcp-setup.md
+++ b/site/docs/getting-started/mcp-setup.md
@@ -6,7 +6,17 @@ sidebar_position: 3
 
 Connect an AI agent (Claude, Cursor, etc.) to your Fyso workspace using the MCP server.
 
-## Option 1: Claude Desktop (manual config)
+## Option 1: Claude Code plugin (recommended)
+
+The `@fyso/claude-plugin` package installs skills, hooks, and the MCP connection in one command:
+
+```bash
+bunx @fyso/claude-plugin install
+```
+
+Authentication uses OAuth — a browser window opens on first use, no API key needed. See [Claude Code Plugin](./claude-plugin.md) for full details.
+
+## Option 2: Claude Desktop (manual config)
 
 Add to `claude_desktop_config.json`:
 
@@ -26,7 +36,7 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
-## Option 2: Smithery
+## Option 3: Smithery
 
 Install directly from Smithery.ai:
 
@@ -34,11 +44,13 @@ Install directly from Smithery.ai:
 npx @smithery/cli install @fyso/mcp-server --client claude
 ```
 
-## Option 3: Anthropic Connectors Directory
+## Option 4: Anthropic Connectors Directory
 
 Find Fyso in the Anthropic MCP Connectors Directory and install with one click.
 
-## Environment Variables
+## Environment Variables (manual config only)
+
+These apply when configuring the MCP server manually (Option 2). The Claude Code plugin handles authentication via OAuth and does not require these variables.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
@@ -57,9 +69,9 @@ list_tenants()
 
 ## Compatible Clients
 
+- Claude Code (via `@fyso/claude-plugin`)
 - Claude Desktop
 - Cursor
-- Claude Code (CLI)
 - Codex
 - Gemini
 - Any MCP-compatible client


### PR DESCRIPTION
## Summary

- New page `getting-started/claude-plugin.md` documents the `@fyso/claude-plugin` package: install command, OAuth authentication flow, CLI commands, status verification, troubleshooting, and plugin manifest field reference.
- Updated `getting-started/mcp-setup.md`: adds the Claude Code plugin as Option 1 (recommended), clarifies that environment variables (`FYSO_API_KEY`, `FYSO_API_URL`) apply only to manual config, reorders compatible clients list.
- Documents the v1.30.2 manifest fix: `agents` field removed from `plugin.json` (field is invalid in the plugin schema), `.mcp.json` switched from `FYSO_API_KEY` header auth to OAuth via `mcp-remote` (no credentials required).

## What changed in the code (commit 7a7d0ca)

```diff
// .claude-plugin/plugin.json
-  "agents": "./agents/",    // directory did not exist; field invalid in schema

// .mcp.json
-  "https://app.fyso.dev/mcp",
-  "--header",
-  "Authorization:Bearer ${FYSO_API_KEY}"
+  "https://app.fyso.dev/mcp"
-  "env": { "FYSO_API_KEY": "" }
```

## Test plan

- [ ] Verify new page renders at `/getting-started/claude-plugin`
- [ ] Verify sidebar position 4 appears after mcp-setup (position 3)
- [ ] Verify link from mcp-setup to claude-plugin resolves correctly
- [ ] Confirm no mention of `FYSO_API_KEY` as required for Claude Code plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)