### PR TITLE
docs: v1.31.0 release notes and agent feature guides

### DIFF
--- a/site/docs/agents/agent-memory.md
+++ b/site/docs/agents/agent-memory.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 8
+---
+
+# Agent Memory
+
+Agent memory lets an agent retain facts about an end user across separate conversations. When enabled, facts are extracted from the conversation after it ends and injected back into the system prompt on subsequent turns with the same user.
+
+## How It Works
+
+1. A conversation runs normally. Memory has no effect during the first session.
+2. After a session accumulates **3 or more user turns**, a background extraction pass runs using the LLM. It reads the conversation and produces a list of deduplicated facts about the user (name, preferences, stated context, etc.).
+3. Facts are stored in the `_fyso_agent_memory` table, keyed by `(tenantId, agentId, externalRef)` — where `externalRef` is the identifier your channel uses to distinguish end users (e.g. a session token or user ID).
+4. On the next conversation with the same user, the 10 most recent facts are retrieved and appended to the agent's system prompt before the first LLM call.
+
+Memory extraction is asynchronous and adds roughly one extra LLM call per qualifying conversation.
+
+## Enabling Memory
+
+Memory is disabled by default. Enable it on the agent config:
+
+```bash
+curl -X PUT https://api.fyso.dev/api/agents-config/<agentId> \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "memory_enabled": true }'
+```
+
+Or toggle it from the agent edit page in the admin panel.
+
+## Database
+
+Memory requires migration **0068**. The migration creates the `_fyso_agent_memory` table:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | uuid | Primary key |
+| `tenant_id` | text | Tenant scope |
+| `agent_id` | text | Agent scope |
+| `external_ref` | text | End-user identifier (from the channel) |
+| `fact` | text | Extracted fact string |
+| `created_at` | timestamp | When the fact was stored |
+
+## Behavior Details
+
+| Condition | Result |
+|-----------|--------|
+| `memory_enabled: false` (default) | No retrieval, no extraction. Existing agents unaffected. |
+| Session has fewer than 3 user turns | Extraction does not run. |
+| Session has 3+ user turns | Extraction runs after the session; facts are deduplicated before insert. |
+| Memory retrieval at conversation start | Up to 10 most recent facts injected into system prompt. |
+
+## Privacy and RGPD
+
+Facts stored in `_fyso_agent_memory` contain information about end users. If you operate under GDPR / RGPD, ensure that:
+
+- Your DPA with Fyso covers memory storage (see [RGPD Compliance](./rgpd-compliance.md)).
+- Data suppression via `DELETE /api/rgpd/users/:externalRef/ai-data` also deletes memory facts for that user.
+- Users who have refused AI consent (`ai_consent: false`) will not trigger memory extraction because the LLM is never called.
+
+## Limitations
+
+- The in-process memory store runs on a single API container. In multi-process deployments, facts are still durable (stored in Postgres) but extraction is fire-and-forget per process.
+- Fact extraction quality depends on the configured LLM and its context window. Very long conversations may result in partial extraction.
+- Memory is scoped per agent. Facts from agent A are not visible to agent B even for the same user.

--- a/site/docs/agents/overview.md
+++ b/site/docs/agents/overview.md
@@ -48,11 +48,14 @@ See [REST API](/docs/api/rest-api) for endpoint reference.
 | Area | What you can do |
 |------|----------------|
 | **Data** | Define entities (tables), create/read/update/delete records, create filtered views, compound filters (AND/OR), semantic search across records |
-| **Logic** | Business rules (event-driven or scheduled), automation flows, webhook subscriptions |
+| **Logic** | Business rules (event-driven or scheduled), automation flows, webhook subscriptions, [visual rule editor](./building-a-site.md) |
 | **Users** | Create tenant users, define roles with entity-level permissions, assign/revoke roles, invitation codes |
 | **Content** | Knowledge base with RAG (upload PDFs, HTML, URLs — then semantic search), PDF generation from templates |
 | **Deploy** | Static sites on `*.sites.fyso.dev`, custom domains (Pro), persistent deploy tokens for CI/CD |
-| **Integration** | Channels (custom MCP tools for bots), bot identity system, publishable apps catalog, n8n community node |
+| **Integration** | Channels (custom MCP tools for bots), [web widget](./web-widget.md), bot identity system, publishable apps catalog, n8n community node |
+| **Memory** | [Agent memory](./agent-memory.md) — fact extraction and retrieval across conversations per end user |
+| **Compliance** | [RGPD / GDPR](./rgpd-compliance.md) — DPA acceptance, session AI consent, data suppression, audit log |
+| **Testing** | [Test panel](./test-panel.md) — live chat with inspector modal (Flow, Steps, Summary, Raw) |
 
 ---
 

--- a/site/docs/agents/rgpd-compliance.md
+++ b/site/docs/agents/rgpd-compliance.md
@@ -1,0 +1,168 @@
+---
+sidebar_position: 9
+---
+
+# RGPD / GDPR Compliance
+
+Fyso provides built-in compliance primitives for operating AI agents under GDPR (called RGPD in Spanish/French contexts). This covers three areas: Data Processing Agreement acceptance by the tenant admin, session-level AI consent from end users, and the right to erasure via data suppression.
+
+## Data Processing Agreement (DPA)
+
+Before using AI features in production, the tenant's administrator must accept the DPA. This acceptance is recorded with a timestamp and the acting admin's ID.
+
+### Accept the DPA
+
+```bash
+curl -X POST https://api.fyso.dev/api/auth/tenants/<tenantId>/dpa-accept \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "dpaAcceptedAt": "2026-03-14T10:00:00.000Z",
+    "dpaAcceptedBy": "admin-user-id"
+  }
+}
+```
+
+### Check DPA Status
+
+```bash
+curl https://api.fyso.dev/api/auth/tenants/<tenantId>/dpa-status \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "accepted": true,
+    "acceptedAt": "2026-03-14T10:00:00.000Z",
+    "acceptedBy": "admin-user-id"
+  }
+}
+```
+
+---
+
+## Session-Level AI Consent
+
+End users interacting with an agent via any channel can be asked whether they consent to AI data processing. The consent flag is stored on the `agent_sessions` row.
+
+### Record Consent
+
+```bash
+curl -X POST https://api.fyso.dev/api/rgpd/sessions/<sessionId>/consent \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "consent": true }'
+```
+
+Set `"consent": false` to record a refusal.
+
+### What Happens With a Refusal
+
+When `ai_consent` is `false` on a session, the agent runner returns a refusal response **without making any LLM call**. The response text is taken from the agent's `fallbackMessages.consent_refused` config key, defaulting to:
+
+> "I cannot process your request because AI data processing consent has been refused for this session."
+
+`ai_consent: null` (not yet collected) allows processing — consent collection is the caller's responsibility and does not block the runner.
+
+### Consent States
+
+| `ai_consent` value | Runner behavior |
+|-------------------|----------------|
+| `null` | Allow — consent not yet collected |
+| `true` | Allow — user has consented |
+| `false` | Block — return refusal, no LLM call |
+
+---
+
+## Data Suppression (Right to Erasure)
+
+Delete all AI data associated with an end user across sessions and call logs.
+
+```bash
+curl -X DELETE \
+  "https://api.fyso.dev/api/rgpd/users/<externalRef>/ai-data" \
+  -H "Authorization: Bearer <api-key>"
+```
+
+Optional query parameter `external_type` filters by channel type if the same `externalRef` value is used across multiple channels.
+
+```bash
+curl -X DELETE \
+  "https://api.fyso.dev/api/rgpd/users/user-123/ai-data?external_type=web" \
+  -H "Authorization: Bearer <api-key>"
+```
+
+This endpoint requires admin role. It deletes:
+- All `agent_sessions` rows for the user
+- All `ai_call_logs` rows for those sessions
+- All `_fyso_agent_memory` facts for the user (if agent memory is enabled)
+
+The deletion is recorded in the consent audit log.
+
+---
+
+## Consent Audit Log
+
+Every consent and suppression event is recorded in `consent_audit_log`.
+
+```bash
+curl "https://api.fyso.dev/api/rgpd/audit-log?limit=50" \
+  -H "Authorization: Bearer <api-key>"
+```
+
+Query parameters:
+
+| Parameter | Description |
+|-----------|-------------|
+| `external_ref` | Filter by end-user identifier |
+| `limit` | Maximum records to return (default 50) |
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "uuid",
+      "event": "consent_given",
+      "externalRef": "user-123",
+      "actorId": null,
+      "metadata": { "consent": true },
+      "createdAt": "2026-03-14T10:05:00.000Z"
+    }
+  ]
+}
+```
+
+Event types: `consent_given`, `consent_refused`, `data_suppressed`.
+
+---
+
+## Database Migrations
+
+RGPD compliance requires two migrations:
+
+| Migration | Changes |
+|-----------|---------|
+| 0067 | `dpa_accepted_at`, `dpa_accepted_by` on `tenants`; `ai_consent`, `ai_consent_at` on `agent_sessions`; `consent_audit_log` table |
+| 0068 | `_fyso_agent_memory` table (agent memory — separate feature, same release) |
+
+---
+
+## Implementation Notes
+
+- DPA routes (`/api/auth/tenants/:id/dpa-*`) require admin authentication via `requireAuth`.
+- Consent and suppression routes (`/api/rgpd/*`) require tenant context (API key or admin session).
+- Suppression and audit log routes require admin role within the tenant.
+- The web widget and other public-facing channel endpoints do not enforce DPA — that check is the tenant operator's responsibility before deploying a public widget.

--- a/site/docs/agents/test-panel.md
+++ b/site/docs/agents/test-panel.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 10
+---
+
+# Agent Test Panel
+
+The test panel lets you chat with an agent directly from the admin panel and inspect every execution detail without deploying to a channel first.
+
+## Accessing the Test Panel
+
+From the agent list, click the flask icon on any agent card. Or navigate to `/agents/:id/test` directly. The agent edit page also has a **Test** button in its sticky footer.
+
+The layout shows two tabs at the top of every agent page: **Edit** and **Test**. Switch between them without losing your place.
+
+## Chat Interface
+
+The test panel is a full chat interface connected to your live agent configuration. Messages are sent to `POST /tenants/:slug/agents/:agentSlug/run` with a persistent `session_id`, so the conversation maintains context across messages within the same test session.
+
+Each message bubble shows its routing path: **Rule** (deterministic fast path) or **LLM** (model call). Click any message to open the inspector.
+
+## Inspector Modal
+
+The inspector modal has four tabs:
+
+### Summary
+
+High-level metrics for the selected run:
+
+- Token counts (input / output)
+- Step count
+- Latency in milliseconds
+- Run ID and Session ID with one-click copy buttons
+
+### Flow
+
+An n8n-style diagram showing the execution path:
+
+```
+User → Agent → [Tool A] → [Tool B] → Response
+               [Tool C]
+```
+
+Tool names are humanized (e.g. `fyso_data` becomes "Fyso Data"). The diagram reflects the actual tools called during that run, not all available tools.
+
+### Steps
+
+Full message history split into two sections:
+
+- **History** — turns from previous messages in the session
+- **Current turn** — the messages exchanged for this specific run, including tool call requests, tool results, and the final assistant response
+
+### Raw
+
+Complete JSON payload for the run. Useful for debugging unexpected behavior or verifying exact token counts and metadata.
+
+## Agent List Quick Actions
+
+Each agent card in the list now shows two quick-action buttons:
+
+| Button | Action |
+|--------|--------|
+| Flask icon | Open test panel for this agent |
+| List icon | Open rules editor for this agent |
+
+## Data Access Scope
+
+The agent form (Edit tab) now includes a **Tools scope** section where you select which entities the agent can access when using data tools. Changes here take effect immediately on the next test run.

--- a/site/docs/agents/web-widget.md
+++ b/site/docs/agents/web-widget.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 7
+---
+
+# Web Widget
+
+The web widget lets you embed a Fyso agent as a floating chat bubble on any website. Add one `<script>` tag and the widget handles everything: session management, message delivery, and UI rendering.
+
+## Quick Start
+
+```html
+<script src="https://api.fyso.dev/api/tenants/{tenantSlug}/agents/{agentSlug}/widget.js"></script>
+```
+
+Replace `{tenantSlug}` and `{agentSlug}` with your tenant and agent identifiers. The script tag is available from the agent's **Channels** tab in the admin panel.
+
+The widget injects a floating chat button at the bottom-right corner of the page. Clicking it opens the chat interface connected directly to your agent.
+
+## How It Works
+
+### Endpoints
+
+The web widget uses three public API endpoints. No tenant authentication is required — access is validated by tenant slug and agent slug matching.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/tenants/:slug/agents/:agentSlug/widget.js` | Returns the embeddable JS snippet |
+| `POST` | `/api/tenants/:slug/agents/:agentSlug/chat` | Send a user message; returns the agent reply |
+| `GET` | `/api/tenants/:slug/agents/:agentSlug/chat/sse` | SSE stream for receiving replies (long-poll, max 30s) |
+
+### Session Management
+
+Sessions are identified by a token stored in `localStorage`. The token is issued on first contact and persists across page loads and browser restarts. It maps to an `externalRef` used throughout the Fyso session system. Users who clear their `localStorage` start a new session.
+
+### CORS
+
+Widget endpoints return `Access-Control-Allow-Origin: *` because they are designed to be embedded on arbitrary customer domains. Sessions use `localStorage` tokens (not cookies), so a wildcard CORS policy is safe.
+
+## Configuration
+
+Widget appearance and behavior is configured on the agent's web channel settings. Available options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `title` | `Chat` | Text shown in the widget header |
+| `primaryColor` | `#6366f1` | Button and header color (any CSS color) |
+| `position` | `bottom-right` | Widget position: `bottom-right` or `bottom-left` |
+| `welcomeMessage` | `Hello! How can I help you today?` | First message shown when the chat opens |
+
+Configure these from the admin panel under **Agents → [your agent] → Channels → Web**.
+
+## Agent Memory and Consent
+
+The web widget generates a `session_token` as the `externalRef` for the session. This token is used as the key for:
+
+- **Agent memory** — if `memory_enabled` is on, facts are stored and retrieved per `session_token`. See [Agent Memory](./agent-memory.md).
+- **RGPD consent** — you can record AI consent for a widget session using the session ID returned in the chat response. See [RGPD Compliance](./rgpd-compliance.md).
+
+## Template Selector
+
+When creating a new agent, the admin panel shows a template selector that lets you start from a pre-configured template instead of from scratch. Templates include predefined rules, system prompts, and channel settings for common use cases. Select a template or choose **Start blank** to configure everything manually.
+
+## Limitations
+
+- The in-process response queue (`WebWidgetAdapter.pendingMessages`) is per-process. In multi-process deployments (multiple API containers behind a load balancer), a user's chat POST and their SSE connection must reach the same process. For horizontally-scaled deployments, back the queue with Redis pub/sub instead.
+- The SSE stream long-polls for up to 30 seconds per connection, then closes. The client reconnects automatically.
+- Widget endpoints do not enforce DPA or AI consent — those checks are the tenant operator's responsibility. See [RGPD Compliance](./rgpd-compliance.md).
+
+## Security Notes
+
+- The widget is intentionally unauthenticated. Protect against abuse using the agent's rate limiting settings and deterministic rules.
+- Input is sanitized server-side (control characters stripped) to prevent prompt injection from the widget UI.
+- The agent slug and tenant slug are validated on every request — a valid combination must exist in the database.

--- a/site/docs/changelog.md
+++ b/site/docs/changelog.md
@@ -212,6 +212,7 @@
 ## v1.31.0 — 2026-03-14
 
 ### Features
+
 - **AI engine** — Fyso now includes a built-in AI engine. Configure AI provider adapters (OpenAI-compatible endpoints, Anthropic) from the admin panel. All AI calls are logged with model, tokens, latency, and cost.
 - **AI budget and rate limiting** — Set monthly token budgets and per-minute rate limits per tenant. Budget estimator shows projected spend before enabling.
 - **Execution context (`$ctx`)** — Business rules and AI actions share an inter-action variable context (`$ctx`). Pass data between rule steps without external storage.
@@ -221,12 +222,24 @@
 - **`test_ai_call` MCP tool** — Prompt playground: test any prompt against any configured provider and see full token/cost breakdown.
 - **Agent runner infrastructure** — Internal agent sessions, runs, and tool-call tables. Foundation for v1.32 Agent Runner.
 - **Semantic tool generator** — Agents auto-generate semantic descriptions of available tools from their `tools_scope` definition.
-- **Agent test panel** — Live chat interface to test agents at `/agents/:id/test`, with run inspector (Summary, Flow, Steps, Raw tabs).
-- **Agent memory** — Enable `memory_enabled: true` on an agent to extract and persist facts across conversations. Facts are injected into the system prompt on subsequent sessions.
-- **GDPR compliance** — DPA acceptance, per-session AI consent, data suppression, and consent audit log. Endpoints: `POST /api/auth/tenants/:id/dpa-accept`, `POST /api/rgpd/sessions/:sessionId/consent`, `DELETE /api/rgpd/users/:externalRef/ai-data`.
-- **Web widget** — Embed an agent as a floating chat bubble with a single `<script>` tag. Configurable title, color, and position.
-- **Visual rules editor** — Drag-and-drop business rules editor at `/agents/:slug/rules` with template variable chips.
-- **AI logs viewer** — `/agents/:slug/logs` shows run history with stats bar, filter panel, and per-run detail dialog.
+- **Agent test panel** — New `/agents/:id/test` page provides a live chat interface to test agents before deploying them. Click any run to open the inspector modal with four tabs: Summary (tokens, latency, run/session IDs), Flow (n8n-style diagram showing User → Agent → tools → Response), Steps (full message history with tool call details), and Raw (complete JSON payload). The agent list and edit pages gain Test (flask) and Rules quick-action buttons. (#1109)
+- **Agent memory** — Agents can now extract and retain facts across conversations. Enable with `memory_enabled: true` on the agent config. After a session reaches 3 user turns, an LLM-based extraction pass runs in the background and stores deduplicated facts in `_fyso_agent_memory` per agent+client pair. Facts are injected into the system prompt on subsequent turns. Off by default; existing agents are unaffected. Requires migration 0068. (#1082)
+- **RGPD / GDPR compliance** — Data Processing Agreement (DPA) acceptance, per-session AI consent, data suppression, and consent audit log. Builder-facing: `POST /api/auth/tenants/:id/dpa-accept` and `GET /api/auth/tenants/:id/dpa-status`. End-user consent: `POST /api/rgpd/sessions/:sessionId/consent`. Data suppression: `DELETE /api/rgpd/users/:externalRef/ai-data`. Audit log: `GET /api/rgpd/audit-log`. Sessions with `ai_consent: false` receive a refusal response without any LLM call. Requires migration 0067. (#1081)
+- **Web widget** — Embed an agent as a floating chat bubble on any website with a single `<script>` tag. The widget serves from public endpoints (no tenant auth required). Sessions persist across page loads via `localStorage`. Supports SSE streaming for replies. Configurable title, primary color, position (`bottom-right` / `bottom-left`), and welcome message via the agent's web channel config. (#1080)
+- **Visual rules editor** — `/agents/:slug/rules` provides a drag-and-drop sortable list of deterministic rules. Match types: exact, contains, starts_with, regex. Template variable chips for dynamic responses. Add/edit/delete via dialog with live preview. Rules are persisted via `PUT /api/agents-config/:id`. (#1079)
+- **AI logs viewer** — `/agents/:slug/logs` shows a table of agent runs with a stats bar (total / success / error / tokens), a filter panel (path × status × time range), and a detail dialog per run showing input, output, tokens, steps, and latency. (#1079)
+
+### Fixes
+
+- **Column names in readEntityFields** — Corrected column names in the `readEntityFields` query. (#1103)
+- **Orphaned tool messages** — Tool messages with no corresponding tool-call entry are now sanitized from session history before sending to the LLM, preventing malformed context errors. (#1104, #1099)
+- **Default model placeholder** — UI placeholder updated from `gpt-4o-mini` to `gpt-4.1`. (#1107)
+- **AI provider i18n** — Fixed interpolation errors and contrast issues in AI provider labels. (#1102)
+- **`max_completion_tokens` for gpt-4o / o1 / o3** — These models require `max_completion_tokens` instead of `max_tokens`; the runner now sends the correct parameter. (#1099)
+- **Rate limit error shape** — 429 responses now return a consistent `{ error, retryAfter }` shape instead of a raw string. (#1097)
+- **Agents list double-unwrap** — Fixed a double `.data.data` unwrap in the agents list API call. (#1096)
+- **Layout scroll** — Corrected a scroll overflow bug in the main layout. (#1098)
+- **Landing animation** — Fixed animation plugin step sequencing on the landing page. (#1106)
 
 ---
 


### PR DESCRIPTION
## Summary

- Changelog entry for v1.31.0 (5 features, 9 fixes)
- New guide: Agent Memory — `memory_enabled` flag, fact extraction, RGPD interaction
- New guide: RGPD / GDPR Compliance — DPA acceptance, session consent, data suppression, audit log
- New guide: Web Widget — embed script, session management, CORS, config options
- New guide: Agent Test Panel — inspector modal (Summary / Flow / Steps / Raw)
- Updated agents overview capabilities table

## Source PRs covered

Features: #1109, #1082, #1081, #1080, #1079
Fixes: #1103, #1104, #1107, #1102, #1106, #1099, #1098, #1097, #1096

## Test plan

- [ ] Build passes (`pluma-deploy`)
- [ ] Changelog renders correctly at /docs/changelog
- [ ] New pages accessible: /docs/agents/agent-memory, /docs/agents/rgpd-compliance, /docs/agents/web-widget, /docs/agents/test-panel
- [ ] All internal links resolve (agent-memory.md <-> rgpd-compliance.md cross-references)
- [ ] Overview table updates render correctly

Generated with Claude Code