### PR TITLE
docs: contains filter behavior and model requirements for tool calling

### DIFF
--- a/site/docs/agents/model-requirements.md
+++ b/site/docs/agents/model-requirements.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 9
+---
+
+# Model Requirements for Tool Calling
+
+Fyso agents use a tool-calling loop: the model receives a list of tools (`query_records`, `create_record`, `update_record`), calls them to retrieve or modify data, then returns a final text response. This loop depends entirely on the model's ability to emit structured `tool_calls` responses.
+
+## What the agent runner expects from a model
+
+The runner sends the OpenAI function-calling format — `tools` in the request body and expects `finish_reason: "tool_calls"` with a `tool_calls` array in the response. If a model does not support this format, the following failure modes occur:
+
+- **Hallucinated data:** the model invents records instead of querying them.
+- **Ignored tools:** the model answers from training data, bypassing your entities entirely.
+- **Silent failure:** the runner interprets the text response as a final answer, returns it, and reports zero tool calls used.
+
+None of these failure modes produce an error — the agent appears to work but returns incorrect data.
+
+## Minimum capability requirements
+
+For reliable tool calling, the model must:
+
+1. Support the OpenAI function-calling API (`tools` parameter, `tool_calls` in response).
+2. Correctly emit `finish_reason: "tool_calls"` when a tool call is needed.
+3. Return valid JSON in `tool_calls[].function.arguments`.
+
+Models that meet these requirements consistently include the **GPT-4o**, **GPT-4.1**, **Claude 3.5+**, and **Llama 3.1 70B+** families. Small models (under ~30B parameters) often claim function-calling support but produce unreliable results in practice.
+
+## Known problematic models
+
+| Model | Issue |
+|-------|-------|
+| `llama-3.1-8b-instant` | Frequently ignores tools; hallucinates records |
+| Other sub-30B instruct models | Variable support — test before deploying |
+
+This list is not exhaustive. Model behavior depends on the provider's fine-tuning and the version deployed.
+
+## How to test a model
+
+Run the agent with a query that requires a tool call and check the response metadata:
+
+```json
+{
+  "response": "...",
+  "steps_used": 1,
+  "tool_calls_count": 1
+}
+```
+
+If `tool_calls_count` is `0` but the agent produced a data-related answer, the model did not use tools. Try a larger model.
+
+## Configuring the model
+
+The `default_model` is set in the AI provider configuration for your tenant (admin panel → AI settings). Fyso does not validate the model name — any string is accepted and passed to the provider. If the provider returns an error for an unsupported model, the agent returns a `not_configured` error.
+
+```json
+{
+  "providers": {
+    "default": {
+      "type": "openai",
+      "base_url": "https://api.groq.com/openai/v1",
+      "default_model": "llama-3.1-70b-versatile"
+    }
+  }
+}
+```
+
+When using a Groq, Together AI, or other OpenAI-compatible endpoint, select a model from their documentation that explicitly lists function-calling / tool-use support.

--- a/site/docs/records/filtering.md
+++ b/site/docs/records/filtering.md
@@ -20,7 +20,7 @@ field operator value
 | `<` | Less than (numeric) | `stock < 10` |
 | `>=` | Greater than or equal | `total >= 500` |
 | `<=` | Less than or equal | `descuento <= 20` |
-| `contains` | Contains text (case-insensitive) | `nombre contains juan` |
+| `contains` | Contains text (case-insensitive, accent-sensitive) | `nombre contains juan` |
 
 ### Examples
 
@@ -30,11 +30,21 @@ query_records({ entityName: "clientes", filter: "nombre contains perez" })
 query_records({ entityName: "facturas", filter: "estado = pagada" })
 ```
 
+### `contains` behavior
+
+`contains` is implemented as a PostgreSQL `ILIKE` query against the stored field value.
+
+**Case sensitivity:** `contains cafe` matches `Cafe`, `CAFE`, and `cafe`. Case is ignored.
+
+**Accent sensitivity:** `ILIKE` does not normalize Unicode. `contains cafe` does **not** match `Café`. To match records with accents, include the accent in the search value: `nombre contains Café`.
+
+**Partial matches:** the value is matched anywhere in the field. `contains an` matches `Juan`, `Ana`, and `Mariana`.
+
 ### Notes
 
-- The filter is applied in memory after fetching the records (except for semantic search)
 - String values do not need quotes, but they are supported: `nombre = "Juan Perez"`
 - Numeric comparisons (`>`, `<`, `>=`, `<=`) convert values to numbers
+- `contains` and `startsWith` filters run as database queries (server-side). All other operators also run server-side when using the `filters=` expression syntax
 
 ## Filters in REST API
 

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/agents/model-requirements.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/agents/model-requirements.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 9
+---
+
+# Requisitos de modelo para tool calling
+
+Los agentes de Fyso usan un loop de tool calling: el modelo recibe una lista de herramientas (`query_records`, `create_record`, `update_record`), las llama para obtener o modificar datos, y luego devuelve una respuesta de texto. Este loop depende completamente de que el modelo pueda emitir respuestas estructuradas con `tool_calls`.
+
+## Que espera el agente del modelo
+
+El runner envia el formato de function calling de OpenAI — `tools` en el cuerpo de la solicitud — y espera `finish_reason: "tool_calls"` con un array `tool_calls` en la respuesta. Si el modelo no soporta este formato, los fallos posibles son:
+
+- **Datos alucinados:** el modelo inventa registros en lugar de consultarlos.
+- **Herramientas ignoradas:** el modelo responde desde su conocimiento de entrenamiento, sin consultar las entidades.
+- **Fallo silencioso:** el runner interpreta la respuesta de texto como respuesta final, la devuelve, y reporta cero tool calls.
+
+Ninguno de estos fallos produce un error — el agente parece funcionar pero devuelve datos incorrectos.
+
+## Requisitos minimos de capacidad
+
+Para un tool calling confiable, el modelo debe:
+
+1. Soportar la API de function calling de OpenAI (parametro `tools`, `tool_calls` en la respuesta).
+2. Emitir correctamente `finish_reason: "tool_calls"` cuando se necesita llamar una herramienta.
+3. Devolver JSON valido en `tool_calls[].function.arguments`.
+
+Los modelos que cumplen estos requisitos de forma consistente incluyen las familias **GPT-4o**, **GPT-4.1**, **Claude 3.5+** y **Llama 3.1 70B+**. Los modelos pequenos (menos de ~30B parametros) frecuentemente declaran soporte para function calling pero producen resultados poco confiables en la practica.
+
+## Modelos con problemas conocidos
+
+| Modelo | Problema |
+|--------|----------|
+| `llama-3.1-8b-instant` | Ignora herramientas con frecuencia; alucina registros |
+| Otros modelos instruct menores a 30B | Soporte variable — probar antes de usar en produccion |
+
+Esta lista no es exhaustiva. El comportamiento del modelo depende del fine-tuning del proveedor y la version desplegada.
+
+## Como probar un modelo
+
+Ejecutar el agente con una consulta que requiera una llamada a herramienta y verificar los metadatos de la respuesta:
+
+```json
+{
+  "response": "...",
+  "steps_used": 1,
+  "tool_calls_count": 1
+}
+```
+
+Si `tool_calls_count` es `0` pero el agente produjo una respuesta relacionada con datos, el modelo no uso herramientas. Probar con un modelo mas grande.
+
+## Configurar el modelo
+
+El `default_model` se configura en la configuracion de proveedor de AI para el tenant (panel de admin → configuracion de AI). Fyso no valida el nombre del modelo — se acepta cualquier string y se pasa al proveedor. Si el proveedor devuelve un error para un modelo no soportado, el agente devuelve un error `not_configured`.
+
+```json
+{
+  "providers": {
+    "default": {
+      "type": "openai",
+      "base_url": "https://api.groq.com/openai/v1",
+      "default_model": "llama-3.1-70b-versatile"
+    }
+  }
+}
+```
+
+Al usar Groq, Together AI u otro endpoint compatible con OpenAI, seleccionar un modelo que liste explicitamente soporte para function calling / tool use en su documentacion.

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/records/filtering.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/records/filtering.md
@@ -20,7 +20,7 @@ campo operador valor
 | `<` | Menor que (numerico) | `stock < 10` |
 | `>=` | Mayor o igual | `total >= 500` |
 | `<=` | Menor o igual | `descuento <= 20` |
-| `contains` | Contiene texto (case-insensitive) | `nombre contains juan` |
+| `contains` | Contiene texto (case-insensitive, sensible a tildes) | `nombre contains juan` |
 
 ### Ejemplos
 
@@ -30,11 +30,21 @@ query_records({ entityName: "clientes", filter: "nombre contains perez" })
 query_records({ entityName: "facturas", filter: "estado = pagada" })
 ```
 
+### Comportamiento de `contains`
+
+`contains` se ejecuta como una consulta `ILIKE` de PostgreSQL contra el valor almacenado en el campo.
+
+**Sensibilidad a mayusculas:** `contains cafe` encuentra `Cafe`, `CAFE` y `cafe`. Las mayusculas se ignoran.
+
+**Sensibilidad a tildes:** `ILIKE` no normaliza Unicode. `contains cafe` **no** encuentra `Café`. Para encontrar registros con tildes, incluir la tilde en el valor de busqueda: `nombre contains Café`.
+
+**Coincidencias parciales:** el valor se busca en cualquier posicion del campo. `contains an` encuentra `Juan`, `Ana` y `Mariana`.
+
 ### Notas
 
-- El filtro se aplica en memoria despues de obtener los registros (salvo busqueda semantica)
 - Los valores string no necesitan comillas, pero se soportan: `nombre = "Juan Perez"`
 - Las comparaciones numericas (`>`, `<`, `>=`, `<=`) convierten los valores a numero
+- Los filtros `contains` y `startsWith` se ejecutan como consultas en base de datos (lado servidor). El resto de operadores tambien se ejecutan lado servidor al usar la sintaxis de expresion `filters=`
 
 ## Filtros en REST API
 


### PR DESCRIPTION
## Summary

- Expands `contains` operator documentation with exact behavior: case-insensitive (PostgreSQL `ILIKE`), accent-sensitive (`cafe` does not match `Café`), partial match semantics explained
- Corrects an inaccurate note in the filters page that claimed filters run in memory — `contains` and `startsWith` run as server-side DB queries
- Adds new `model-requirements.md` (English + Spanish) explaining minimum model capabilities for tool calling, known problematic models (`llama-3.1-8b-instant`), how to verify a model works, and how to configure `default_model`

Closes #1236

## Source verified

- `contains` → `ILIKE` confirmed in `packages/api/src/services/record.service.ts:302`
- No `unaccent` extension in the filter path — accent sensitivity is expected behavior
- Agent runner model config in `packages/api/src/ai/agent-runner.ts` — no server-side model validation, passes `default_model` directly to provider

## Test plan

- [ ] Build site locally and verify new `model-requirements.md` renders under the Agents section
- [ ] Confirm `contains` section in Filters page renders correctly (EN + ES)
- [ ] Verify no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)