### PR TITLE
docs: v1.36.x-v1.38.0 — organizations, SSE events, agent messaging

### DIFF
--- a/site/docs/admin/organizations.md
+++ b/site/docs/admin/organizations.md
@@ -1,0 +1,140 @@
+---
+sidebar_position: 2
+---
+
+# Organizations
+
+Organizations are the layer between admin users and tenants. An org groups tenants under a shared billing plan and lets multiple admins collaborate on the same workspace.
+
+## Conceptual model
+
+```
+Admin user
+  └── Organization (plan lives here)
+        ├── Tenant A
+        ├── Tenant B
+        └── Tenant C
+```
+
+Every admin gets a **personal org** automatically on signup. You can create additional orgs — for example, one per client — and invite collaborators to each.
+
+## Plan limits
+
+| Plan | Tenants per org | Org members |
+|------|----------------|-------------|
+| Free | 1 | Owner only |
+| Pro | 5 | Unlimited |
+| Enterprise | Custom | Unlimited |
+
+## Creating an org
+
+**Admin panel:** Dashboard → top-left switcher → "New Organization"
+
+**MCP:**
+
+```
+fyso_auth({ action: "create_org", orgName: "Acme Corp" })
+```
+
+**REST:**
+
+```bash
+curl -X POST https://api.fyso.dev/api/orgs \
+  -H "Authorization: Bearer <admin_token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Acme Corp" }'
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "uuid",
+    "name": "Acme Corp",
+    "slug": "acme-corp",
+    "plan": "free",
+    "owner_id": "uuid",
+    "created_at": "2026-03-01T00:00:00Z"
+  }
+}
+```
+
+## Inviting members
+
+Inviting an admin by email sends them a pending invitation. They must accept before getting access.
+
+**MCP:**
+
+```
+fyso_auth({ action: "invite_to_org", orgId: "<org-id>", email: "partner@example.com", orgRole: "member" })
+```
+
+**REST:**
+
+```bash
+curl -X POST https://api.fyso.dev/api/orgs/<org-id>/members \
+  -H "Authorization: Bearer <admin_token>" \
+  -H "Content-Type: application/json" \
+  -d '{ "email": "partner@example.com", "role": "member" }'
+```
+
+| Role | Permissions |
+|------|-------------|
+| `owner` | Full access, can delete org, manage billing |
+| `member` | Access to all tenants, cannot delete org or modify billing |
+
+### Accepting an invitation
+
+Invited admins receive an email with a link to `/signup/org-invite?token=<token>`. If they already have an account, they log in and are added immediately. New users can register from the same page.
+
+## Listing orgs
+
+```
+fyso_auth({ action: "list_orgs" })
+```
+
+Returns all orgs the authenticated admin belongs to (as owner or member).
+
+## Listing org members
+
+```
+fyso_auth({ action: "list_org_members", orgId: "<org-id>" })
+```
+
+## Switching orgs
+
+The top-left switcher in the admin panel shows all orgs and their tenants in a hierarchical list. Click an org to expand it, then click a tenant to switch to it.
+
+## MCP tool reference
+
+These actions are part of `fyso_auth`:
+
+| Action | Required params | Description |
+|--------|----------------|-------------|
+| `list_orgs` | — | List all orgs for the current admin |
+| `create_org` | `orgName` | Create a new org |
+| `invite_to_org` | `orgId`, `email` | Invite an admin to an org |
+| `list_org_members` | `orgId` | List members of an org |
+
+## REST API endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/orgs` | List orgs for current admin |
+| `POST` | `/api/orgs` | Create org |
+| `GET` | `/api/orgs/:id` | Get org details |
+| `PATCH` | `/api/orgs/:id` | Update org name/slug |
+| `DELETE` | `/api/orgs/:id` | Delete org (owner only) |
+| `GET` | `/api/orgs/:id/members` | List members |
+| `POST` | `/api/orgs/:id/members` | Invite member by email |
+| `DELETE` | `/api/orgs/:id/members/:memberId` | Remove member |
+| `GET` | `/api/orgs/invitations/:token` | Get invitation details |
+| `POST` | `/api/orgs/invitations/:token/accept` | Accept an org invitation |
+
+## Billing
+
+Plans are attached to orgs, not individual admin users. The Billing page is at `/org/billing`. See [Plans](../billing/plans.md) for available plans and limits.
+
+> **Migration note:** Accounts created before v1.36.0 were automatically migrated to a personal org. Their existing plan was preserved.

--- a/site/docs/agents/external-identity.md
+++ b/site/docs/agents/external-identity.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 10
+---
+
+# External Agent Identity
+
+External agents — processes running outside Fyso, such as Claude Code agents or autonomous scripts — can register a persistent identity with a tenant. This identity lets them receive messages via SSE without polling and participate in multi-agent pipelines.
+
+## The `.fyso-agent` file
+
+After registering, a Fyso agent identity is stored in a `.fyso-agent` file in the agent's working directory:
+
+```json
+{
+  "agent_id": "cero-a3f2c1",
+  "agent_name": "cero",
+  "tenant": "my-workspace",
+  "registered_at": "2026-03-23T10:00:00Z"
+}
+```
+
+The `agent_id` has the format `<name>-<6 hex chars>`, making it unique per instance even if multiple agents share the same name.
+
+## Registering
+
+```bash
+curl -X POST https://api.fyso.dev/api/v1/tenants/<slug>/agents/register \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "agent_name": "cero" }'
+```
+
+Response `201`:
+
+```json
+{
+  "success": true,
+  "data": {
+    "agent_id": "cero-a3f2c1",
+    "agent_name": "cero",
+    "tenant": "my-workspace",
+    "registered_at": "2026-03-23T10:00:00Z"
+  }
+}
+```
+
+Store the `agent_id` in `.fyso-agent`. You only need to register once per agent instance. On subsequent runs, use the reconnect endpoint to validate the stored identity.
+
+## Reconnecting
+
+On startup, an agent should validate its stored `agent_id` before connecting to the SSE stream:
+
+```bash
+curl -X POST https://api.fyso.dev/api/v1/tenants/<slug>/agents/reconnect \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "agent_id": "cero-a3f2c1" }'
+```
+
+- `200` — identity is valid, proceed.
+- `404` with `AGENT_NOT_FOUND` — the `.fyso-agent` file is stale (database was reset, tenant was recreated, etc.). Re-register with `POST /register` and update the file.
+
+## Subscribing to messages via SSE
+
+Once registered, the agent can subscribe to its incoming messages:
+
+```bash
+curl -N "https://api.fyso.dev/api/v1/tenants/<slug>/events/stream?agent_id=cero-a3f2c1" \
+  -H "Authorization: Bearer <api_key>"
+```
+
+The `agent_id` parameter is validated on connect. A `404` response at connection time means the identity is stale — re-register first.
+
+When another agent sends a message with `auto_run: false`, the SSE stream delivers a `message.received` event:
+
+```
+event: message.received
+data: {
+  "id": "msg_uuid",
+  "type": "message.received",
+  "timestamp": "2026-03-23T10:00:00Z",
+  "tenant": "my-workspace",
+  "to_agent": "cero-a3f2c1",
+  "from_agent": "pluma-b7e2d4",
+  "message_id": "uuid",
+  "subject": "PR review complete",
+  "priority": "normal"
+}
+```
+
+## Multiple instances
+
+Registering the same `agent_name` multiple times creates distinct identities (different suffixes). Each instance has its own inbox. Use the exact `agent_id` from `.fyso-agent` to subscribe to the correct inbox.
+
+## Authentication
+
+Both `fyso_pkey_*` (platform keys) and `fyso_ak_*` (tenant API keys) are accepted on the register and reconnect endpoints.
+
+## REST API endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/tenants/:slug/agents/register` | Register new external agent identity |
+| `POST` | `/api/v1/tenants/:slug/agents/reconnect` | Validate existing identity on reconnection |

--- a/site/docs/agents/messaging.md
+++ b/site/docs/agents/messaging.md
@@ -1,0 +1,200 @@
+---
+sidebar_position: 9
+---
+
+# Agent Messaging
+
+Fyso agents can send and receive messages to each other using the `_agent_messages` system entity. This enables multi-agent pipelines where agents coordinate work asynchronously.
+
+## How it works
+
+1. Agent A sends a message to Agent B using `fyso_agents({ action: "send_message", ... })`.
+2. The message lands in Agent B's inbox with status `pending`.
+3. If `auto_run: true`, the server runs Agent B automatically with the message as its input.
+4. Agent B can reply by sending a message back with `in_reply_to` set to the original message ID, forming a thread.
+
+Chains are limited to **5 hops**. If a chain would exceed the limit, the message is left as `pending` and a `message.chain_limit` SSE event is emitted.
+
+## Sending a message
+
+**MCP:**
+
+```
+fyso_agents({
+  action: "send_message",
+  to_agent: "inventory-agent",
+  subject: "Low stock alert",
+  payload: { product_id: "uuid", current_stock: 3 },
+  priority: "high",
+  auto_run: true
+})
+```
+
+**REST:**
+
+```bash
+curl -X POST https://api.fyso.dev/api/tenants/<slug>/agent-messages/send \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from_agent": "warehouse-monitor",
+    "to_agent": "inventory-agent",
+    "subject": "Low stock alert",
+    "payload": { "product_id": "uuid", "current_stock": 3 },
+    "priority": "high",
+    "auto_run": true
+  }'
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "message_id": "uuid",
+    "from_agent": "warehouse-monitor",
+    "to_agent": "inventory-agent-a3f2c1",
+    "subject": "Low stock alert",
+    "priority": "high",
+    "status": "pending",
+    "created_at": "2026-03-23T10:00:00Z"
+  }
+}
+```
+
+### Agent name resolution
+
+The `to_agent` field supports fuzzy matching:
+
+- Exact slug match → resolved immediately.
+- Single prefix match: `"cero"` resolves to `"cero-b4e5d6"` if that is the only agent whose slug starts with `cero-`.
+- Multiple prefix matches → error with a list of candidates.
+
+### Message fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `to_agent` | string | Yes | Recipient agent name or slug (fuzzy matching) |
+| `from_agent` | string | No | Sender name. Defaults to `mcp-caller` when using MCP |
+| `subject` | string | No | Optional subject line |
+| `payload` | object | No | Arbitrary JSON data (max 64 KB) |
+| `priority` | `normal` \| `high` \| `urgent` | No | Default: `normal` |
+| `in_reply_to` | string | No | UUID of the parent message (enables threading) |
+| `auto_run` | boolean | No | Run recipient agent automatically on delivery |
+
+## Reading the inbox
+
+```
+fyso_agents({
+  action: "inbox",
+  agent_name: "inventory-agent",
+  inbox_status: "pending"
+})
+```
+
+| `inbox_status` | Returns |
+|---------------|---------|
+| `pending` | Unread messages (default) |
+| `read` | Already-read messages |
+| `all` | All messages |
+
+**REST:**
+
+```bash
+GET /api/tenants/<slug>/agent-messages/inbox/<agentName>?status=pending&limit=50
+```
+
+## Reading a single message
+
+Fetching a message marks it as `read`.
+
+```
+fyso_agents({ action: "read_message", message_id: "<uuid>" })
+```
+
+**REST:**
+
+```bash
+GET /api/tenants/<slug>/agent-messages/<messageId>/read
+```
+
+## Archiving a message
+
+```
+fyso_agents({ action: "archive_message", message_id: "<uuid>" })
+```
+
+**REST:**
+
+```bash
+POST /api/tenants/<slug>/agent-messages/<messageId>/archive
+```
+
+## Counting unread messages
+
+```
+fyso_agents({ action: "count_unread", agent_name: "inventory-agent" })
+```
+
+**REST:**
+
+```bash
+GET /api/tenants/<slug>/agent-messages/count/<agentName>
+```
+
+Response:
+
+```json
+{ "agent": "inventory-agent-a3f2c1", "unread": 4 }
+```
+
+## Auto-run and chain depth
+
+When `auto_run: true` is set and the recipient is a Fyso agent, the server runs the agent immediately in the background. The HTTP response returns before the agent finishes — the run is fire-and-forget.
+
+The agent receives the message as its user input with this context:
+
+```
+trigger=message
+message_id=<uuid>
+from_agent=<sender>
+subject=<subject>
+payload=<json>
+thread_depth=<depth>
+max_depth=5
+```
+
+**Chain depth limit:** If following the `in_reply_to` chain back to the root produces 5 or more hops, the auto-run is skipped. The message is left as `pending` and a `message.chain_limit` SSE event is emitted on the event stream. You can monitor this event to detect runaway loops.
+
+## SSE notifications
+
+External agents can subscribe to incoming messages via the SSE event stream. Pass your `agent_id` (from `.fyso-agent`) as a query parameter:
+
+```bash
+curl -N "https://api.fyso.dev/api/v1/tenants/<slug>/events/stream?agent_id=<agent_id>" \
+  -H "Authorization: Bearer <api_key>"
+```
+
+Incoming messages arrive as `message.received` events. Chain-limit notifications arrive as `message.chain_limit`. See [SSE Event Stream](../api/sse-events.md) for full details.
+
+## Access control
+
+| Caller type | Can read/send |
+|------------|---------------|
+| Admin token / API key | Any agent inbox |
+| Bot JWT (participant) | Own inbox only, own `from_agent` only |
+
+## Inbox limits
+
+Each agent inbox holds at most **1000 pending messages**. Sending to a full inbox returns an error.
+
+## REST API endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/tenants/:slug/agent-messages/send` | Send a message |
+| `GET` | `/api/tenants/:slug/agent-messages/inbox/:agentName` | List inbox |
+| `GET` | `/api/tenants/:slug/agent-messages/:messageId/read` | Fetch + mark read |
+| `POST` | `/api/tenants/:slug/agent-messages/:messageId/archive` | Archive |
+| `GET` | `/api/tenants/:slug/agent-messages/count/:agentName` | Count unread |

--- a/site/docs/api/mcp-tools.md
+++ b/site/docs/api/mcp-tools.md
@@ -8,8 +8,6 @@ Complete reference of all available MCP tools.
 
 The MCP server exposes **10 grouped tools** (each with an `action` enum parameter), plus `fyso_welcome` for onboarding. Configure which tools are exposed with the `FYSO_TOOLS` environment variable. See [Tool Profiles](tool-profiles.md).
 
-Channels, bots, flows, webhooks, and other features are available via the [REST API](/api/rest-api) but not as MCP tools.
-
 ## How grouped tools work
 
 Each grouped tool accepts an `action` parameter that selects the operation. Additional parameters depend on the action chosen. Example:
@@ -110,7 +108,6 @@ Create, test, publish, and manage business rules.
 | `create` | Create rule from DSL | `name`, `triggerType`, `rule` |
 | `get` | Rule details | `ruleId` |
 | `list` | List rules | — |
-| `generate` | Generate from prompt/DSL | `description` or `rule` |
 | `publish` | Activate draft rule | `ruleId` |
 | `delete` | Delete rule | `ruleId` |
 | `test` | Dry-run with test data | `ruleId`, `testData` |
@@ -124,22 +121,22 @@ Create, test, publish, and manage business rules.
 | `entityName` | string | all | Entity the rule belongs to |
 | `ruleId` | string | get, publish, delete, test, logs | Rule ID |
 | `name` | string | create | Rule name |
-| `description` | string | create, generate | Rule description or natural language prompt |
+| `description` | string | create | Rule description |
 | `triggerType` | `field_change` \| `before_save` \| `after_save` \| `on_load` | create | When the rule triggers |
 | `triggerFields` | string[] | create | Fields that trigger the rule |
-| `rule` | object | create, generate | Rule DSL with compute/validate/transform/actions |
-| `ruleDsl` | object | create, generate | Alias for `rule` |
+| `rule` | object | create | Rule DSL with compute/validate/transform/actions |
+| `ruleDsl` | object | create | Alias for `rule` |
 | `priority` | number | create | Execution priority, lower = first (default: 100) |
-| `auto_publish` | boolean | create, generate | Auto-publish after create/generate |
+| `auto_publish` | boolean | create | Auto-publish after create |
 | `include_drafts` | boolean | list | Include draft rules |
 | `testData` | object | test | Test record data for dry-run |
 | `limit` | number | logs | Max log entries |
 
 ---
 
-## `fyso_auth` — Users, roles, and tenants
+## `fyso_auth` — Users, roles, tenants, and organizations
 
-User management, RBAC, and tenant operations.
+User management, RBAC, tenant operations, organization management, and API keys.
 
 | Action | Description | Required params |
 |--------|-------------|-----------------|
@@ -153,25 +150,37 @@ User management, RBAC, and tenant operations.
 | `login` | Authenticate as tenant user | `tenantSlug`, `email`, `password` |
 | `list_tenants` | List accessible tenants | — |
 | `select_tenant` | Select active tenant | `tenantSlug` |
+| `create_tenant` | Create a new tenant (plan quota enforced: free=1, pro=5) | `name` |
 | `generate_invitation` | Generate beta invitation code (FYSO-XXXX-XXXX) | — |
 | `list_invitations` | List invitation codes with usage stats | — |
+| `list_orgs` | List organizations for current admin | — |
+| `create_org` | Create a new organization | `orgName` |
+| `invite_to_org` | Invite an admin to an org | `orgId`, `email` |
+| `list_org_members` | List members of an org | `orgId` |
+| `create_api_key` | Create a tenant API key | — |
 
 ### Parameters
 
 | Param | Type | Used by | Description |
 |-------|------|---------|-------------|
 | `action` | string (enum) | all | Operation to perform |
-| `email` | string | create_user, login | User email |
+| `email` | string | create_user, login, invite_to_org | User or invitee email |
 | `name` | string | create_user, create_role | User or role name |
 | `password` | string | create_user, update_password, login | Password |
 | `userId` | string | update_password, assign_role, revoke_role | User ID |
 | `roleId` | string | assign_role, revoke_role | Role ID |
 | `permissions` | object | create_role | Role permissions object |
 | `description` | string | create_role | Role description |
-| `tenantSlug` | string | create_user, login, select_tenant, update_password | Tenant slug |
+| `tenantSlug` | string | create_user, login, select_tenant, update_password | Tenant slug. `select_tenant` supports prefix matching — if no exact match, auto-selects when one prefix match is found. |
 | `note` | string | generate_invitation | Optional note for the invitation |
 | `maxUses` | number | generate_invitation | Max uses for the code |
 | `expiresAt` | string | generate_invitation | Expiration date (ISO 8601) |
+| `orgName` | string | create_org | Organization display name |
+| `orgId` | string | invite_to_org, list_org_members | Organization ID |
+| `orgRole` | `owner` \| `member` | invite_to_org | Role to assign the invitee (default: `member`) |
+| `apiKeyName` | string | create_api_key | Optional name for the new API key |
+
+> **`create_api_key` note:** The full key is returned only once in the response — store it immediately. Subsequent calls return only the key prefix for identification.
 
 ---
 
@@ -283,41 +292,72 @@ API spec, client generation, metadata import/export, secrets, and usage metrics.
 | `tenantId` | string | export, import | Tenant ID/slug override |
 | `key` | string | set_secret, delete_secret | Secret name |
 | `value` | string | set_secret | Secret value (encrypted at rest) |
+| `feedback_type` | `bug` \| `suggestion` \| `question` | feedback | Feedback category |
+| `title` | string | feedback | Short summary |
+| `description` | string | feedback | Detailed description |
+| `context` | string | feedback | Optional additional context |
 
 ---
 
 ## `fyso_agents` — Agent management
 
-Create, configure, and run AI agents. Manage versions, runs, and templates.
+Create, configure, run AI agents, and send messages between agents. Manage versions, runs, and templates.
 
 | Action | Description | Required params |
 |--------|-------------|-----------------|
 | `list` | List all agents | — |
 | `create` | Create a new agent | `name` |
-| `update` | Modify an agent | `agentId` |
-| `delete` | Delete an agent | `agentId` |
-| `run` | Execute an agent with input | `agentId`, `input` |
-| `test` | Run agent in sandbox mode | `agentId`, `input` |
-| `list_runs` | List agent run history | `agentId` |
-| `list_versions` | List prompt versions | `agentId` |
-| `rollback` | Revert to a previous version | `agentId`, `versionId` |
+| `update` | Modify an agent | `id` or `slug` |
+| `delete` | Delete an agent | `slug` |
+| `run` | Execute an agent with input | `agent_slug`, `message` |
+| `test` | Run agent in sandbox mode | `agent_slug`, `message` |
+| `list_runs` | List agent run history | `agent_id` |
+| `list_versions` | List prompt versions | `agent_id` |
+| `rollback` | Revert to a previous version | `agent_id`, `version` |
 | `list_templates` | List industry preset templates | — |
-| `from_template` | Create agent from template | `templateId`, `name` |
+| `from_template` | Create agent from template | `template_id`, `name` |
+| `send_message` | Send a message to another agent | `to_agent` |
+| `inbox` | View an agent's inbox | `agent_name` |
+| `read_message` | Fetch a message and mark it read | `message_id` |
+| `archive_message` | Archive a message | `message_id` |
+| `count_unread` | Count pending messages for an agent | `agent_name` |
 
 ### Parameters
 
 | Param | Type | Used by | Description |
 |-------|------|---------|-------------|
 | `action` | string (enum) | all | Operation to perform |
-| `agentId` | string | update, delete, run, test, list_runs, list_versions, rollback | Agent ID |
-| `name` | string | create, from_template | Agent name |
-| `input` | string | run, test | User message or prompt |
-| `versionId` | string | rollback | Version ID to restore |
-| `templateId` | string | from_template | Template ID |
+| `id` | string | update | Agent UUID (preferred over slug for update) |
+| `slug` | string | update, delete | Agent slug identifier |
+| `agent_slug` | string | run, test | Agent slug |
+| `agent_id` | string | list_runs, list_versions, rollback | Agent UUID |
+| `name` | string | create, from_template | Agent display name |
+| `message` | string | run, test | User message input |
+| `version` | number | rollback | Version number to restore |
+| `template_id` | string | from_template | Template identifier |
+| `session_id` | string | run, list_runs | Session ID to continue or filter by |
 | `memory_enabled` | boolean | create, update | Enable cross-session memory extraction |
-| `tools_scope` | string[] | create, update | List of tool names available to the agent |
+| `knowledge_enabled` | boolean | create, update | Enable RAG retrieval from tenant knowledge base |
+| `schedules_enabled` | boolean | create, update | Enable scheduling tools (slots, bookings) |
+| `tools_scope` | object | create, update | Entity tools: `{ "entity": ["query", "create", "update"] }` |
 | `system_prompt` | string | create, update | Agent system prompt |
+| `fallback_mode` | `llm` \| `message` \| `silent` | create, update | Behavior when no deterministic rule matches |
 | `channels` | object[] | create, update | Channel configurations (web, telegram, etc.) |
+| **Messaging params** | | | |
+| `to_agent` | string | send_message | Recipient agent name or slug. Supports fuzzy matching: `"cero"` resolves to `"cero-a3f2c1"` if unique. |
+| `from_agent` | string | send_message | Sender name. Defaults to `mcp-caller`. |
+| `subject` | string | send_message | Optional subject line |
+| `payload` | object | send_message | Arbitrary JSON data (max 64 KB) |
+| `priority` | `normal` \| `high` \| `urgent` | send_message | Default: `normal` |
+| `in_reply_to` | string | send_message | UUID of parent message (for threading) |
+| `auto_run` | boolean | send_message | Run recipient agent automatically on delivery |
+| `agent_name` | string | inbox, count_unread | Agent whose inbox to access |
+| `message_id` | string | read_message, archive_message | Message UUID |
+| `inbox_status` | `pending` \| `read` \| `all` | inbox | Filter messages by status (default: `pending`) |
+| `inbox_limit` | number | inbox | Max messages (default 50, max 200) |
+| `inbox_offset` | number | inbox | Pagination offset |
+
+See [Agent Messaging](../agents/messaging.md) for the full guide.
 
 ---
 
@@ -337,6 +377,10 @@ Configure AI providers, manage prompts, test calls, and view logs.
 | `create_template` | Create a reusable prompt template | `name`, `prompt` |
 | `list_templates` | List prompt templates | — |
 | `update_template` | Modify a prompt template | `templateId` |
+| `list_presets` | List industry presets (taller, clinica, tienda) | — |
+| `install_preset` | Install an industry preset with entities and agent | `preset` |
+| `rate_limit_status` | Current AI rate limit status | — |
+| `cost_dashboard` | AI spend summary (weekly, monthly, projections) | — |
 
 ### Parameters
 
@@ -352,6 +396,10 @@ Configure AI providers, manage prompts, test calls, and view logs.
 | `templateId` | string | update_template | Template ID |
 | `callId` | string | debug_log | AI call ID (requires `ai.debug` tenant setting) |
 | `limit` | number | call_logs | Max log entries |
+| `preset` | string | install_preset | Preset name: `taller`, `clinica`, `tienda` |
+| `system_prompt` | string | test_call | System prompt for test call |
+| `temperature` | number | test_call | Temperature 0–2 |
+| `max_tokens` | number | test_call | Max tokens 1–32000 |
 
 ---
 
@@ -367,12 +415,34 @@ This tool does not accept an `action` parameter — it is a single-purpose tool,
 
 ---
 
+## Integration management tools
+
+These standalone tools manage the integration lifecycle (not grouped):
+
+| Tool | Description | Required params |
+|------|-------------|-----------------|
+| `list_integrations` | List available integrations and status | — |
+| `install_integration` | Install an integration | `slug` |
+| `configure_integration` | Update integration config | `slug`, `config` |
+| `activate_integration` | Enable integration tools | `slug` |
+| `test_integration` | Test connectivity | `slug` |
+| `uninstall_integration` | Remove integration | `slug` |
+| `list_integration_logs` | View health logs | `slug` |
+
+Active integrations inject tools into agent runners as `integration:<slug>:<tool-slug>`.
+
+---
+
 ## REST-only features
 
 The following features are available via the [REST API](/api/rest-api) but are not exposed as MCP tools:
 
-- **Channels** — `search_channels`, `get_channel_info`, `get_channel_tools`, `execute_channel_tool`, `publish_channel`, `update_channel`, `unpublish_channel`, `set_channel_permissions`, `define_channel_tool`, `update_channel_tool`, `remove_channel_tool`
-- **Bots** — `register_bot`, `identify_bot`, `list_bots`, `whoami_bot`, `revoke_bot` (see [Bot Identity](/agents/bot-identity))
+- **SSE Event Stream** — `GET /api/v1/tenants/:slug/events/stream` — real-time CRUD, rule, and agent message events. See [SSE Event Stream](/api/sse-events).
+- **External Agent Identity** — `POST /api/v1/tenants/:slug/agents/register`, `POST /reconnect`. See [External Agent Identity](/agents/external-identity).
+- **Agent Messages (REST)** — Send, inbox, read, archive, count. Also available via `fyso_agents` MCP actions. See [Agent Messaging](/agents/messaging).
+- **Organizations** — `/api/orgs` CRUD + members + invitations. Also available via `fyso_auth` MCP actions. See [Organizations](/admin/organizations).
+- **Channels** — Agent channel management (Telegram, web widget). See [Channels](/admin/channels).
+- **Bots** — `register_bot`, `identify_bot`, `list_bots`, `whoami_bot`, `revoke_bot`. See [Bot Identity](/agents/bot-identity).
 - **Flows** — `create_flow`, `list_flows`, `update_flow`, `delete_flow`, `toggle_flow`
 - **Webhooks** — `create_webhook`, `list_webhooks`, `delete_webhook`
 - **Documents** — `upload_document`, `list_documents`, `get_document`, `delete_document`

--- a/site/docs/api/sse-events.md
+++ b/site/docs/api/sse-events.md
@@ -1,0 +1,206 @@
+---
+sidebar_position: 5
+---
+
+# SSE Event Stream
+
+The SSE (Server-Sent Events) stream delivers real-time tenant events to connected clients without polling. Events are pushed as they happen — record CRUD, rule executions, and agent messages.
+
+## Endpoint
+
+```
+GET /api/v1/tenants/:slug/events/stream
+```
+
+## Authentication
+
+Pass a tenant API key (`fyso_ak_*` or `fyso_pkey_*`) in the `Authorization` header:
+
+```bash
+curl -N "https://api.fyso.dev/api/v1/tenants/my-workspace/events/stream" \
+  -H "Authorization: Bearer fyso_ak_..."
+```
+
+The key must belong to the specified tenant. Admin session tokens are not accepted on this endpoint.
+
+## Connection limits
+
+| Limit | Value |
+|-------|-------|
+| Max connections per tenant | 5 |
+| Max connections globally | 100 |
+| Backpressure threshold | 100 queued events |
+| Idle timeout | 1 hour |
+| Heartbeat interval | 30 seconds |
+
+If the per-tenant or global limit is reached, the endpoint returns `429`.
+
+Slow consumers that fall more than 100 events behind receive a `backpressure` error event and the connection is closed.
+
+## Heartbeat
+
+The server sends a `: ping` comment every 30 seconds to keep the connection alive through proxies and load balancers. Standard SSE clients ignore comments; custom parsers should discard lines that start with `:`.
+
+## Query parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `entities` | Comma-separated entity names to filter record events. Omit to receive all entities. Example: `?entities=invoices,clients` |
+| `events` | Comma-separated event types to receive. Omit to receive all event types. Example: `?events=record.created,rule.executed` |
+| `agent_id` | Agent ID from `.fyso-agent`. When set, also delivers `message.received` events addressed to this agent. |
+
+You can combine filters:
+
+```bash
+curl -N "https://api.fyso.dev/api/v1/tenants/my-workspace/events/stream?entities=orders&events=record.created,rule.executed" \
+  -H "Authorization: Bearer fyso_ak_..."
+```
+
+## Event types
+
+| Type | Trigger |
+|------|---------|
+| `record.created` | A record was created in any entity |
+| `record.updated` | A record was updated |
+| `record.deleted` | A record was deleted |
+| `rule.executed` | A business rule ran and completed successfully |
+| `rule.failed` | A business rule ran and threw an error |
+| `message.received` | An agent message was delivered (requires `?agent_id=`) |
+| `message.chain_limit` | An auto-run chain was halted at depth 5 |
+| `connected` | Sent immediately on connect (prevents proxy timeout) |
+| `error` | Stream-level error (`IDLE_TIMEOUT`, `BACKPRESSURE`) |
+
+## Event shapes
+
+### Record events
+
+```
+event: record.created
+id: 42
+data: {
+  "id": "evt_uuid",
+  "type": "record.created",
+  "timestamp": "2026-03-23T10:00:00Z",
+  "tenant": "my-workspace",
+  "entity": "orders",
+  "record_id": "uuid",
+  "data": {
+    "fields": { "status": "pending", "total": 150.00 },
+    "triggered_by": "api"
+  }
+}
+```
+
+The `triggered_by` field identifies what initiated the change:
+
+| Value | Meaning |
+|-------|---------|
+| `mcp` | MCP tool call |
+| `api` | Direct REST API call |
+| `flow` | Automation flow |
+| `webhook` | Incoming webhook |
+| `ui` | Web admin panel |
+| `rule` | Rules engine (e.g. `update_related`) |
+| `system` | Internal (migrations, seeding) |
+
+### Rule events
+
+```
+event: rule.executed
+id: 43
+data: {
+  "id": "evt_uuid",
+  "type": "rule.executed",
+  "timestamp": "2026-03-23T10:00:00Z",
+  "tenant": "my-workspace",
+  "data": {
+    "rule_name": "notify-on-payment",
+    "trigger_type": "after_save",
+    "entity": "orders",
+    "record_id": "uuid",
+    "result": "completed"
+  }
+}
+```
+
+`rule.failed` uses the same shape but includes `error` instead of `result`:
+
+```json
+{
+  "data": {
+    "rule_name": "notify-on-payment",
+    "trigger_type": "after_save",
+    "entity": "orders",
+    "record_id": "uuid",
+    "error": "Integration timeout after 10s"
+  }
+}
+```
+
+### Message events
+
+Only delivered when `?agent_id=<id>` is set:
+
+```
+event: message.received
+id: 44
+data: {
+  "id": "msg_uuid",
+  "type": "message.received",
+  "timestamp": "2026-03-23T10:00:00Z",
+  "tenant": "my-workspace",
+  "to_agent": "cero-a3f2c1",
+  "from_agent": "pluma-b7e2d4",
+  "message_id": "uuid",
+  "subject": "PR review complete",
+  "priority": "normal"
+}
+```
+
+The payload of the message is not included in the SSE event. Fetch it with `GET /agent-messages/:messageId/read`.
+
+### Error events
+
+```
+event: error
+data: { "type": "error", "code": "IDLE_TIMEOUT", "message": "Connection closed due to inactivity" }
+```
+
+```
+event: error
+data: { "type": "error", "code": "BACKPRESSURE", "message": "Connection closed: client is too slow to consume events" }
+```
+
+## Reconnection
+
+The SSE `id` field is set on every event. Standard clients that support `Last-Event-ID` will send it on reconnect; the server does not replay missed events in the current implementation. If replay is required, re-fetch the relevant records via the REST API after reconnecting.
+
+## Example: Node.js client
+
+```js
+import EventSource from 'eventsource';
+
+const stream = new EventSource(
+  'https://api.fyso.dev/api/v1/tenants/my-workspace/events/stream?entities=orders',
+  { headers: { Authorization: 'Bearer fyso_ak_...' } }
+);
+
+stream.addEventListener('record.created', (e) => {
+  const event = JSON.parse(e.data);
+  console.log('New order:', event.record_id, event.data.fields);
+});
+
+stream.addEventListener('error', (e) => {
+  if (e.data) console.error('Stream error:', JSON.parse(e.data));
+});
+```
+
+## Example: Using the Fyso Claude Code skill
+
+The `/fyso:listen` skill connects the SSE stream to a Claude Code channel:
+
+```
+/fyso:listen
+```
+
+This establishes a live event bridge for the current tenant. Events appear as channel messages in the Claude Code session.

--- a/site/docs/changelog.md
+++ b/site/docs/changelog.md
@@ -1,3 +1,128 @@
+## v1.38.0 — 2026-03-23
+
+### Features — Agent Messaging
+- **`_agent_messages` system entity** — Tenant-scoped inbox table for agent-to-agent communication. Created automatically in every tenant schema.
+- **Messaging actions in `fyso_agents`** — Five new MCP actions: `send_message`, `inbox`, `read_message`, `archive_message`, `count_unread`. See [Agent Messaging](./agents/messaging.md).
+- **Agent name fuzzy resolution** — `send_message` resolves partial names: `"cero"` auto-resolves to `"cero-a3f2c1"` if unique. Returns candidates list when ambiguous.
+- **Auto-run on message** — Setting `auto_run: true` on a message triggers the recipient Fyso agent immediately in the background. Fire-and-forget; HTTP response returns before the run completes.
+- **Chain depth limit** — Auto-run chains halt at 5 hops. The 6th message is left as `pending` and a `message.chain_limit` SSE event is emitted.
+
+### Features — External Agent Identity
+- **`.fyso-agent` file + registration handshake** — External agents (e.g. Claude Code) can register a persistent identity with `POST /api/v1/tenants/:slug/agents/register`. The `agent_id` is stored in `.fyso-agent` and used to subscribe to incoming messages via SSE. See [External Agent Identity](./agents/external-identity.md).
+- **Reconnect validation** — `POST /agents/reconnect` validates a stored `agent_id` and updates `last_seen_at`. Returns `AGENT_NOT_FOUND` if the file is stale.
+
+### Features — SSE and Event Bus
+- **`TriggeredBy` field** — All `record.*` events now include `data.triggered_by`: `mcp`, `api`, `flow`, `webhook`, `ui`, `rule`, or `system`.
+- **Rule events** — `rule.executed` and `rule.failed` events stream via SSE after every `after_save` rule execution.
+- **`?events=` filter** — SSE connections can filter by event type: `?events=record.created,rule.executed`. Omit for all types.
+- **`?agent_id=` filter** — SSE connections can subscribe to incoming agent messages by passing `agent_id` from `.fyso-agent`.
+- **Event bus coverage** — All CRUD paths (including the agent runner) now emit events.
+
+### Features — Developer Experience
+- **`forceDebug` in agent test UI** — Debug info is always visible in the agent test panel, regardless of the `ai.debug` tenant setting.
+- **`create_api_key` in `fyso_auth`** — Create a tenant API key from an MCP session. The full key is returned once only.
+
+### Fixes
+- **DB connection pool** — `max_lifetime` set to 240 s, `keep_alive` enabled at 10 s. Prevents `CONNECTION_CLOSED` errors under high load.
+- **SSE stability** — Accepts both `fyso_pkey_*` and legacy `fyso_ak_*` keys. Sends immediate `connected` event on open to prevent proxy timeout. `idleTimeout` set to 255 s via `Bun.serve`. `X-Accel-Buffering: no` header disables Nginx proxy buffering.
+- **UUID guard** — `findById`/`findByIds` now reject non-UUID strings before hitting the database, preventing `PostgresError` from LLM tool calls.
+
+---
+
+## v1.37.0 — 2026-03-20
+
+### Features — Channels Fase 1
+- **In-process event bus** — Tenant-scoped EventEmitter for CRUD events. Emits `record.created`, `record.updated`, `record.deleted` from all write paths.
+- **SSE endpoint** — `GET /api/v1/tenants/:slug/events/stream` — persistent Server-Sent Events stream for tenant events. See [SSE Event Stream](./api/sse-events.md).
+- **`/fyso:listen` skill** — Claude Code skill that bridges the SSE stream to a Claude Code channel.
+
+### Features
+- **Unified login** — The tenant workspace field on the login page expands inline; `/login/tenant` removed.
+- **`create_api_key` in `fyso_auth`** — Backported to v1.37; creates a tenant API key from MCP.
+
+### Fixes
+- **Org invitation email** — Invitation email is now sent when inviting a user to an org.
+- **Stale chunk auto-reload** — `ChunkLoadError` after a deploy now triggers an automatic page reload.
+- **UUID guard on record lookups** — Non-UUID ids from LLM tool calls no longer reach the database.
+- **i18n dynamic keys** — `bulk_tab_files` and `bulk_tab_urls` translation keys now expand correctly.
+- **SSE proxy hardening** — `fyso_pkey_*` keys accepted; immediate `connected` event; 255 s idle timeout; `X-Accel-Buffering: no`.
+
+### Cleanup
+- **Dead invitation code removed** — `invitation_codes` table and `platform_invitations` table deleted (−1,094 lines). Beta access is now controlled via the admin panel directly.
+
+---
+
+## v1.36.3 — 2026-03-19
+
+### Fixes
+- **Server startup guard** — Missing `SECRETS_ENCRYPTION_KEY` now causes an immediate fatal error with a clear message and the generation command, instead of silently hanging.
+- **Org UX** — Fixed org switcher navigation, plan expiry display, role badge rendering, and personal org name disambiguation.
+
+---
+
+## v1.36.2 — 2026-03-19
+
+### Fixes
+- **Org invitation acceptance** — Inviting an existing user now creates a pending invitation instead of auto-adding them. Membership is granted only after the user accepts.
+- **Org UI scroll** — Content below the fold on org pages is now reachable.
+
+---
+
+## v1.36.1 — 2026-03-19
+
+### Features
+- **`POST /api/orgs/invitations/:token/accept`** — New authenticated endpoint for accepting org invitations.
+
+### Fixes
+- **Org invitation acceptance** — Inviting an existing user creates a pending invitation instead of auto-adding them.
+- **Personal org names** — Personal orgs show the owner name for disambiguation (`"Personal (slug)"` for other admins' orgs).
+- **Owner/member badges** — Crown and Users icons in the org and tenant switcher.
+- **Dashboard scroll** — Content below the fold is reachable.
+
+---
+
+## v1.36.0 — 2026-03-19
+
+### Features — Organizations
+- **Organization layer** — Orgs sit between admin users and tenants (similar to Supabase projects/teams). Every admin gets a personal org on signup; existing users were migrated automatically.
+- **Billing on org** — Plans (`Free`, `Pro`, `Beta`, `Enterprise`) moved from admin user to org. Quota enforcement reads from org plan.
+- **Multi-org support** — Admins can create multiple orgs and switch between them via the top-left switcher.
+- **Org invitations** — Invite collaborators to an org by email. Invited admins get access to all tenants in that org. Free plan: no invitations. Pro+: unlimited.
+- **New MCP tools** — `list_orgs`, `create_org`, `invite_to_org`, `list_org_members` actions added to `fyso_auth`. See [Organizations](./admin/organizations.md).
+- **New REST endpoints** — Full CRUD under `/api/orgs` plus members and invitations. See [Organizations](./admin/organizations.md).
+
+### Frontend
+- **Org+Tenant switcher** — Hierarchical dropdown in TopNav: org list with collapsible tenant groups.
+- **Organization sidebar group** — Members, Billing, and Org Settings pages under a new sidebar section.
+- **Members page** (`/org/members`) — Invite by email, manage roles, revoke pending invitations.
+- **Billing page moved** — `/billing` redirects to `/org/billing`.
+- **Org Settings** (`/org/settings`) — Name, slug, delete org (owner only).
+- **Invitation accept page** (`/signup/org-invite`) — Register or log in to join an org.
+
+### Breaking changes
+- `POST /api/auth/tenants` accepts `org_id` in the body. If omitted, defaults to the personal org.
+- `/billing` redirects to `/org/billing`.
+- `admin_users.plan` is deprecated — read from `organizations.plan` via org membership. Billing webhooks dual-write during the transition period.
+
+---
+
+## v1.34.0 — 2026-03-17
+
+### Features
+- **Multi-user tenant admin** — Tenant owners can invite users with specific roles. Invitation flow carries the assigned role. Includes role assignment audit log, admin action attribution, and tenant-user login via `/login/tenant`.
+- **resolve_depth on single record** — `GET /entities/:name/records/:id?resolve_depth=1` now resolves relations without needing `?resolve=true`. Max depth aligned to 2 across all endpoints.
+- **Agent retry on rate limit** — Agent runner retries with exponential backoff when the AI provider returns 429 (rate limited).
+
+### Fixes
+- **Consistent 429 error shape** — Rate limit middleware now returns a standard `{ error: "RATE_LIMITED", ... }` response across all endpoints.
+- **Stable record ordering** — Records query adds a secondary sort key (`id`) to prevent non-deterministic ordering when multiple records share the same sort field value.
+- **Agent run authentication** — Agent run endpoint now accepts both session tokens and API keys, not just admin tokens.
+- **Agent creation warning** — Creating an agent when no AI provider is configured returns a warning in the response instead of failing silently at run time.
+- **MCP `select_tenant` fuzzy match** — `select_tenant` now tries prefix matching when no exact slug match is found. Auto-selects if exactly one match; lists candidates if multiple.
+- **`generate_business_rule` removed** — The unreliable NL-to-DSL tool has been removed. Use `create_business_rule` with agent-generated DSL instead.
+
+---
+
 ## v1.33.2 — 2026-03-15
 
 ### Security


### PR DESCRIPTION
## Summary

- New page: `admin/organizations.md` — org layer, multi-admin, billing on org, MCP actions, REST endpoints
- New page: `agents/messaging.md` — agent-to-agent messaging, auto-run, chain depth limit
- New page: `agents/external-identity.md` — .fyso-agent file, register/reconnect handshake, SSE subscription
- New page: `api/sse-events.md` — SSE stream reference, all event types, shapes, filters, limits
- Updated: `api/mcp-tools.md` — 5 new fyso_agents messaging actions, 4 fyso_auth org actions + create_api_key
- Updated: `changelog.md` — entries for v1.36.0 through v1.38.0

All behavior verified against source code in fyso_backend.

## Test plan
- [x] Build passes (confirmed locally with npx docusaurus build)
- [ ] New pages render correctly in the sidebar
- [ ] Internal links between new pages resolve
- [ ] Changelog entries match release notes

Generated with Claude Code