### PR TITLE
Sync changelog and align scheduling documentation with engine

### DIFF
--- a/admin/import-export.md
+++ b/admin/import-export.md
@@ -6,7 +6,7 @@ Exportar e importar la estructura (entidades, campos, reglas) de un tenant.
 
 **Perfil:** core
 
-Exporta la metadata del tenant actual a un JSON.
+Exporta la metadata del tenant actual. En MCP, la herramienta devuelve un resumen corto en texto y guarda la exportacion completa en un archivo JSON temporal.
 
 ### Parametros
 
@@ -22,7 +22,14 @@ export_metadata()
 
 ### Respuesta
 
-Retorna un JSON con la estructura completa:
+Retorna un resumen en texto similar a:
+
+```text
+Export completed: 3 entities, 2 rules (18.4 KB)
+Saved to: /tmp/fyso-export-mi-tenant-2026-04-09T21-30-00.json
+```
+
+El archivo guardado contiene la estructura completa de la exportacion:
 
 ```json
 {
@@ -39,11 +46,20 @@ Retorna un JSON con la estructura completa:
 }
 ```
 
+### Comportamiento de la HTTP API
+
+Si llamas directamente a `/metadata/export` en lugar de usar la herramienta MCP:
+
+- Las respuestas normales usan el envelope JSON estandar `{ success, data }`
+- Si el cliente envia `Accept-Encoding: gzip` y el payload supera el umbral, el servidor puede responder con `application/gzip`
+- Las respuestas gzip incluyen los headers `X-Original-Size` y `X-Compressed-Size`
+- Las respuestas JSON y gzip contienen la misma metadata
+
 ## MCP Tool: `import_metadata`
 
 **Perfil:** core
 
-Importa metadata desde un JSON a un tenant.
+Importa metadata a un tenant.
 
 ### Parametros
 
@@ -56,12 +72,18 @@ Importa metadata desde un JSON a un tenant.
 
 ```
 import_metadata({
-  metadata: '{"entities":[...],"version":"1.0"}'
+  metadata: JSON.stringify({
+    version: "1.0",
+    entities: [...],
+    businessRules: [...]
+  })
 })
 ```
 
 ### Notas
 
+- El parametro MCP `metadata` es un string JSON
+- El endpoint HTTP `/metadata/import` acepta tanto un body JSON como un body gzip (`application/gzip` o `Content-Encoding: gzip`)
 - La importacion crea las entidades y campos del sistema (`isSystem=true`)
 - Los campos custom (`isSystem=false`) creados con `manage_custom_fields` NO se ven afectados
 - Si una entidad ya existe, se actualizan sus campos del sistema

--- a/api/mcp-tools.md
+++ b/api/mcp-tools.md
@@ -2,7 +2,7 @@
 
 Complete reference of all MCP tools available in Fyso.
 
-The MCP server exposes **8 grouped tools** (each with an `action` enum parameter) plus **7 super admin tools**. No individual tools are exposed. Configure which tools are available with the `FYSO_TOOLS` environment variable. See [Tool Profiles](tool-profiles.md).
+The MCP server exposes **10 grouped tools** (each with an `action` enum parameter), plus `fyso_welcome` and `setup_scheduling`. Legacy tool names such as `export_metadata` and `import_metadata` are still dispatched for backward compatibility. Configure which tools are available with the `FYSO_TOOLS` environment variable. See [Tool Profiles](tool-profiles.md).
 
 ## How grouped tools work
 
@@ -14,6 +14,18 @@ fyso_data({ action: "query", entity: "tasks", filters: "status = open" })
 fyso_auth({ action: "list_tenants" })
 ```
 
+## Standalone utility tools
+
+These tools are advertised separately from the grouped routers:
+
+| Tool | Description | Notes |
+|------|-------------|-------|
+| `fyso_welcome` | First-run onboarding helper | Suggests an initial schema based on business type |
+| `setup_scheduling` | Initialise scheduling system entities | Run once on a new tenant before `get_slots` or `create_booking` |
+| `export_metadata` | Backward-compatible metadata export tool | See [Import / Export Metadata](../admin/import-export.md) |
+| `import_metadata` | Backward-compatible metadata import tool | See [Import / Export Metadata](../admin/import-export.md) |
+
+---
 ---
 
 ## `fyso_data` — Records and scheduling

--- a/scheduling/availability.md
+++ b/scheduling/availability.md
@@ -1,85 +1,156 @@
 # Disponibilidad y horarios
 
-El sistema de turnos de Fyso calcula disponibilidad automaticamente a partir de tres entidades.
+El motor de scheduling de Fyso calcula disponibilidad a partir de tres entidades de sistema:
+
+- `_fyso_schedules`
+- `_fyso_schedule_exceptions`
+- `_fyso_bookings`
+
+Estas entidades son independientes de entidades de dominio como `doctors`, `patients` o `appointments`.
+
+## Setup
+
+Ejecuta `setup_scheduling` una vez por tenant, o llama a `POST /api/scheduling/setup`.
+
+El setup es idempotente. Crea y publica las tres entidades `_fyso_*` si no existen.
 
 ## Entidades requeridas
 
-Para usar el sistema de turnos, el tenant debe tener estas tres entidades:
+### `_fyso_schedules`
 
-### `horarios`
+Horarios regulares de cada profesional.
 
-Define los horarios regulares de cada profesional.
+| `fieldKey` | `fieldType` | Requerido | Descripcion |
+|------------|-------------|-----------|-------------|
+| `professional_id` | `text` | Si | UUID del profesional |
+| `rrule` | `text` | Si | String RRULE RFC 5545 |
+| `start_time` | `text` | No | Hora de inicio `HH:MM`. Default `09:00` si falta |
+| `end_time` | `text` | No | Hora de fin `HH:MM`. Default `17:00` si falta |
+| `slot_duration` | `number` | No | Duracion del slot en minutos. Default `30` si falta |
+| `active` | `boolean` | No | Si el horario esta activo. Default `true` |
 
-| Campo | Tipo | Descripcion |
-|-------|------|-------------|
-| `profesional_id` | relation | Referencia al profesional |
-| `rrule` | text | Regla de recurrencia (formato RFC 5545 / RRule) |
-| `hora_inicio` | text | Hora de inicio (HH:MM) |
-| `hora_fin` | text | Hora de fin (HH:MM) |
-| `duracion_turno` | number | Duracion de cada slot en minutos |
-| `activo` | boolean | Si el horario esta activo |
+Ejemplo:
 
-Ejemplo de `rrule`: `RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` (lunes a viernes).
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "rrule": "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR",
+  "start_time": "09:00",
+  "end_time": "13:00",
+  "slot_duration": 30,
+  "active": true
+}
+```
 
-### `excepciones_horario`
+### `_fyso_schedule_exceptions`
 
-Define excepciones al horario regular (feriados, dias especiales).
+Dias bloqueados o sobrescrituras de horario especial.
 
-| Campo | Tipo | Descripcion |
-|-------|------|-------------|
-| `profesional_id` | relation | Referencia al profesional |
-| `fecha` | date | Fecha de la excepcion (YYYY-MM-DD) |
-| `tipo` | select | `"bloqueado"` (no atiende) o `"horario_especial"` |
-| `hora_inicio` | text | Hora de inicio (solo para `horario_especial`) |
-| `hora_fin` | text | Hora de fin (solo para `horario_especial`) |
+| `fieldKey` | `fieldType` | Requerido | Descripcion |
+|------------|-------------|-----------|-------------|
+| `professional_id` | `text` | Si | UUID del profesional |
+| `date` | `date` | Si | Fecha de excepcion en `YYYY-MM-DD` |
+| `type` | `select` | Si | `blocked` o `special_hours` |
+| `start_time` | `text` | No | Requerido cuando `type = "special_hours"` |
+| `end_time` | `text` | No | Requerido cuando `type = "special_hours"` |
 
-### `turnos`
+Ejemplo de dia bloqueado:
 
-Los turnos reservados.
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "date": "2026-05-01",
+  "type": "blocked"
+}
+```
 
-| Campo | Tipo | Descripcion |
-|-------|------|-------------|
-| `profesional_id` | relation | Referencia al profesional |
-| `paciente_id` | relation | Referencia al paciente/cliente |
-| `fecha` | date | Fecha del turno (YYYY-MM-DD) |
-| `hora` | text | Hora del turno (HH:MM) |
-| `duracion` | number | Duracion en minutos |
-| `estado` | select | `"confirmado"`, `"cancelado"`, etc. |
-| `notas` | textarea | Notas opcionales |
+Ejemplo de horario especial:
+
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "date": "2026-05-02",
+  "type": "special_hours",
+  "start_time": "10:00",
+  "end_time": "12:00"
+}
+```
+
+### `_fyso_bookings`
+
+Reservas confirmadas que el motor usa para descartar slots ocupados.
+
+| `fieldKey` | `fieldType` | Requerido | Descripcion |
+|------------|-------------|-----------|-------------|
+| `professional_id` | `text` | Si | UUID del profesional |
+| `patient_id` | `text` | Si | UUID del paciente/cliente |
+| `date` | `date` | Si | Fecha del turno en `YYYY-MM-DD` |
+| `time` | `text` | Si | Hora del turno en `HH:MM` |
+| `duration` | `number` | No | Duracion en minutos |
+| `status` | `select` | Si | `confirmed`, `cancelled` o `completed` |
+| `notes` | `textarea` | No | Notas opcionales |
+
+## Notas sobre RRULE
+
+El motor usa `rrule` para decidir en que fechas aplica el horario, y luego combina eso con `start_time`, `end_time` y `slot_duration`.
+
+- `rrule` define los dias activos.
+- `start_time` y `end_time` definen la ventana horaria de cada fecha.
+- `slot_duration` define el tamanio de cada slot.
+- Si `DTSTART` no viene en el string, el motor lo agrega automaticamente segun el rango consultado.
+
+Horario tipico de lunes a viernes por la maniana:
+
+```text
+FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
+```
+
+Todos los lunes de 09:00 a 13:00:
+
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "rrule": "FREQ=WEEKLY;BYDAY=MO",
+  "start_time": "09:00",
+  "end_time": "13:00",
+  "slot_duration": 30,
+  "active": true
+}
+```
 
 ## MCP Tool: `get_available_slots`
 
 **Perfil:** core
 
-Calcula los slots disponibles considerando horarios, excepciones y turnos existentes.
+Calcula slots disponibles considerando horarios, excepciones y bookings confirmados.
 
 ### Parametros
 
 | Parametro | Tipo | Requerido | Descripcion |
 |-----------|------|-----------|-------------|
-| `profesional_id` | string | Si | UUID del profesional |
-| `fecha` | string | No | Fecha especifica (YYYY-MM-DD) |
-| `desde` | string | No | Inicio del rango (YYYY-MM-DD) |
-| `hasta` | string | No | Fin del rango (YYYY-MM-DD, max 90 dias) |
+| `professional_id` | string | Si | UUID del profesional |
+| `date` | string | No | Fecha especifica en `YYYY-MM-DD` |
+| `from` | string | No | Inicio del rango en `YYYY-MM-DD` |
+| `to` | string | No | Fin del rango en `YYYY-MM-DD` |
 
-Proporcionar `fecha` para un dia, o `desde`/`hasta` para un rango.
+Usa `date` para un solo dia, o `from` y `to` para un rango. Maximo: 90 dias.
 
 ### Ejemplo: un dia
 
-```
+```js
 get_available_slots({
-  profesional_id: "uuid-del-profesional",
-  fecha: "2026-02-20"
+  professional_id: "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  date: "2026-05-05"
 })
 ```
 
-### Ejemplo: rango de fechas
+### Ejemplo: rango
 
-```
+```js
 get_available_slots({
-  profesional_id: "uuid-del-profesional",
-  desde: "2026-02-20",
-  hasta: "2026-02-28"
+  professional_id: "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  from: "2026-05-05",
+  to: "2026-05-09"
 })
 ```
 
@@ -87,16 +158,71 @@ get_available_slots({
 
 ```json
 [
-  { "fecha": "2026-02-20", "hora": "09:00", "duracion": 30, "profesional_id": "uuid" },
-  { "fecha": "2026-02-20", "hora": "09:30", "duracion": 30, "profesional_id": "uuid" },
-  { "fecha": "2026-02-20", "hora": "10:00", "duracion": 30, "profesional_id": "uuid" }
+  {
+    "date": "2026-05-05",
+    "time": "09:00",
+    "duration": 30,
+    "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002"
+  },
+  {
+    "date": "2026-05-05",
+    "time": "09:30",
+    "duration": 30,
+    "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002"
+  }
 ]
 ```
 
-### Logica de calculo
+## REST API
 
-1. Obtiene los horarios activos del profesional
-2. Genera slots segun `hora_inicio`, `hora_fin` y `duracion_turno`
-3. Aplica la regla de recurrencia (`rrule`) para determinar que dias aplica
-4. Excluye fechas bloqueadas y ajusta horarios especiales
-5. Excluye slots que ya tienen un turno confirmado
+REST usa los mismos nombres de parametros que MCP:
+
+```text
+GET /api/scheduling/available-slots?professional_id=<uuid>&date=2026-05-05
+GET /api/scheduling/available-slots?professional_id=<uuid>&from=2026-05-05&to=2026-05-09
+```
+
+## Troubleshooting
+
+### `422 Scheduling entities not found`
+
+El tenant todavia no fue inicializado para scheduling.
+
+Solucion:
+
+```js
+setup_scheduling()
+```
+
+o:
+
+```text
+POST /api/scheduling/setup
+```
+
+### Respuesta vacia
+
+Un array vacio es valido cuando:
+
+- el profesional no tiene horarios activos
+- el rango no tiene ocurrencias que matcheen el RRULE
+- todas las fechas quedaron bloqueadas por excepciones
+- todos los slots ya estan reservados
+
+### RRULE invalido
+
+Un RRULE invalido no rompe la request, pero no genera fechas. Verifica primero el formato.
+
+## Compatibilidad legacy
+
+Tenants viejos pueden seguir teniendo nombres legacy como `horarios`, `excepciones_horario`, `turnos`, o field keys como `profesional_id` y `fecha`.
+
+Fyso migra esas entidades de sistema a nombres `_fyso_*` y field keys en ingles. La documentacion nueva usa solo los nombres actuales.
+
+## Preset `clinica`
+
+El preset `clinica` instala entidades de dominio como `doctors`, `patients` y `appointments`.
+
+Esas entidades no son la capa de almacenamiento del scheduling engine. El motor lee solo `_fyso_schedules`, `_fyso_schedule_exceptions` y `_fyso_bookings`.
+
+Si instalas `clinica` y quieres usar `get_available_slots` o `create_booking`, ejecuta `setup_scheduling` y modela el scheduling en las entidades `_fyso_*`, o agrega tu propia capa de sincronizacion/reglas entre las entidades de dominio y el sistema de scheduling.

--- a/scheduling/bookings.md
+++ b/scheduling/bookings.md
@@ -1,87 +1,123 @@
-# Reservas (Bookings)
+# Reservas
 
 ## MCP Tool: `create_booking`
 
 **Perfil:** core
 
-Crea una reserva validando primero que el slot este disponible.
+Crea una reserva despues de validar que el slot siga disponible.
+
+La reserva se guarda en `_fyso_bookings` con `status = "confirmed"`.
 
 ### Parametros
 
 | Parametro | Tipo | Requerido | Descripcion |
 |-----------|------|-----------|-------------|
-| `profesional_id` | string | Si | UUID del profesional |
-| `paciente_id` | string | Si | UUID del paciente/cliente |
-| `fecha` | string | Si | Fecha (YYYY-MM-DD) |
-| `hora` | string | Si | Hora (HH:MM) |
-| `duracion` | number | No | Duracion en minutos. Default: duracion del slot del profesional |
-| `notas` | string | No | Notas opcionales |
-
-### Flujo interno
-
-1. Consulta slots disponibles para la fecha
-2. Verifica que `fecha + hora` este en la lista de slots disponibles
-3. Si esta disponible, crea un registro en la entidad `turnos` con `estado = "confirmado"`
-4. Si no esta disponible, retorna error
+| `professional_id` | string | Si | UUID del profesional |
+| `patient_id` | string | Si | UUID del paciente/cliente |
+| `date` | string | Si | Fecha en `YYYY-MM-DD` |
+| `time` | string | Si | Hora en `HH:MM` |
+| `duration` | number | No | Duracion en minutos. Default: tamanio de slot del horario |
+| `notes` | string | No | Notas opcionales |
 
 ### Ejemplo
 
-```
+```js
 create_booking({
-  profesional_id: "uuid-del-profesional",
-  paciente_id: "uuid-del-paciente",
-  fecha: "2026-02-20",
-  hora: "10:00",
-  notas: "Control de rutina"
+  professional_id: "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  patient_id: "1f8f3577-365a-4e28-aa41-88e8cb4a351e",
+  date: "2026-05-05",
+  time: "10:00",
+  notes: "Routine checkup"
 })
 ```
+
+### Flujo interno
+
+1. Valida UUIDs y formatos de fecha/hora.
+2. Verifica que el tenant tenga inicializadas las entidades de scheduling.
+3. Calcula disponibilidad actual para el slot pedido.
+4. Crea un registro en `_fyso_bookings` con `status = "confirmed"` si el slot sigue libre.
+5. Rechaza la request si el slot no existe o ya fue tomado.
 
 ### Respuesta exitosa
 
 ```json
 {
   "success": true,
-  "message": "Booking created for 2026-02-20 at 10:00",
-  "record": {
-    "id": "uuid-del-turno",
-    "profesional_id": "uuid",
-    "paciente_id": "uuid",
-    "fecha": "2026-02-20",
-    "hora": "10:00",
-    "duracion": 30,
-    "estado": "confirmado",
-    "notas": "Control de rutina"
+  "data": {
+    "id": "uuid-del-booking",
+    "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+    "patient_id": "1f8f3577-365a-4e28-aa41-88e8cb4a351e",
+    "date": "2026-05-05",
+    "time": "10:00",
+    "duration": 30,
+    "status": "confirmed",
+    "notes": "Routine checkup"
   }
 }
 ```
 
-### Error: slot no disponible
+### Errores comunes
+
+Slot no disponible:
 
 ```json
 {
   "success": false,
-  "error": "Slot 2026-02-20 10:00 is not available for this professional"
+  "error": "Slot 2026-05-05 10:00 is not available for this professional"
 }
 ```
 
-## Cancelar un turno
+Scheduling no inicializado:
 
-No hay tool dedicado para cancelar. Actualizar el registro directamente:
-
-```
-update_record({
-  entityName: "turnos",
-  recordId: "uuid-del-turno",
-  data: { estado: "cancelado" }
-})
+```json
+{
+  "success": false,
+  "error": "Scheduling entities not found. Run setup_scheduling (MCP) or POST /scheduling/setup to initialise _fyso_schedules, _fyso_schedule_exceptions, and _fyso_bookings."
+}
 ```
 
 ## REST API
 
-El endpoint REST para disponibilidad:
+Crear booking:
 
-```
-GET /api/scheduling/available-slots?profesional_id=uuid&fecha=2026-02-20
+```text
+POST /api/scheduling/bookings
+Authorization: Bearer TOKEN
+Content-Type: application/json
 ```
 
-Headers: `Authorization: Bearer TOKEN`
+Body:
+
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "patient_id": "1f8f3577-365a-4e28-aa41-88e8cb4a351e",
+  "date": "2026-05-05",
+  "time": "10:00",
+  "duration": 30,
+  "notes": "Routine checkup"
+}
+```
+
+Consulta de disponibilidad:
+
+```text
+GET /api/scheduling/available-slots?professional_id=<uuid>&date=2026-05-05
+```
+
+## Cancelacion
+
+Todavia no hay una tool dedicada para cancelar reservas.
+
+Para cancelar, actualiza el registro en `_fyso_bookings` y pon:
+
+```json
+{ "status": "cancelled" }
+```
+
+## Notas
+
+- `create_booking` usa nombres de parametros en ingles tanto en MCP como en REST.
+- El motor no escribe en entidades de dominio como `appointments`.
+- Si tu tenant usa el preset `clinica`, trata `_fyso_bookings` como estado interno del scheduling engine y agrega tu propia sincronizacion hacia `appointments` si tu flujo de producto necesita ambos.

--- a/site/docs/admin/import-export.md
+++ b/site/docs/admin/import-export.md
@@ -49,6 +49,8 @@ The export endpoint wraps its response in the standard API envelope. The MCP too
 
 When working via REST, the schema payload lives inside `data`.
 
+When working via REST, the schema payload lives inside `data`. When working via MCP, the grouped `fyso_meta` export action returns a short text summary plus the temp file path where the full JSON was written.
+
 ### What gets exported
 
 - Only **published** entities (drafts are excluded)
@@ -58,13 +60,13 @@ When working via REST, the schema payload lives inside `data`.
 
 ### Content negotiation
 
-For payloads larger than 10 KB, the server returns the response compressed as `application/gzip` — but **only** when the client sends the header:
+For payloads larger than 10 KB, the server may return the response compressed as `application/gzip` — but **only** when the client sends:
 
 ```
-Accept: application/gzip
+Accept-Encoding: gzip
 ```
 
-The `Accept-Encoding: gzip` header is transport-level and does **not** trigger a gzip content-type response. If neither header is present (or `Accept: application/json` is used), the response is always `application/json`.
+If the client omits that header, or explicitly uses `Accept-Encoding: identity`, the response stays `application/json` in the standard envelope.
 
 When gzip is returned, the response includes two diagnostic headers:
 
@@ -82,6 +84,8 @@ When gzip is returned, the response includes two diagnostic headers:
 ```
 fyso_meta({ action: "import", data: "<json-string>" })
 ```
+
+The grouped MCP action delegates to the legacy metadata import tool. The `data` field must be a JSON string.
 
 ### REST endpoint
 

--- a/site/docs/api/mcp-tools.md
+++ b/site/docs/api/mcp-tools.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 Complete reference of all available MCP tools.
 
-The MCP server exposes **10 grouped tools** (each with an `action` enum parameter), plus `fyso_welcome` for onboarding. Configure which tools are exposed with the `FYSO_TOOLS` environment variable. See [Tool Profiles](tool-profiles.md).
+The MCP server exposes **10 grouped tools** (each with an `action` enum parameter), plus `fyso_welcome` and `setup_scheduling`. Legacy tool names such as `export_metadata` and `import_metadata` are still dispatched for backward compatibility. Configure which tools are exposed with the `FYSO_TOOLS` environment variable. See [Tool Profiles](tool-profiles.md).
 
 ## How grouped tools work
 
@@ -18,6 +18,18 @@ fyso_data({ action: "query", entity: "tasks", filters: "status = open" })
 fyso_auth({ action: "list_tenants" })
 ```
 
+## Standalone utility tools
+
+These tools are advertised separately from the grouped routers:
+
+| Tool | Description | Notes |
+|------|-------------|-------|
+| `fyso_welcome` | First-run onboarding helper | Suggests an initial schema based on business type |
+| `setup_scheduling` | Initialise scheduling system entities | Run once on a new tenant before `get_slots` or `create_booking` |
+| `export_metadata` | Backward-compatible metadata export tool | See [Import / Export Metadata](/docs/admin/import-export) |
+| `import_metadata` | Backward-compatible metadata import tool | See [Import / Export Metadata](/docs/admin/import-export) |
+
+---
 ---
 
 ## `fyso_data` — Records and bookings

--- a/site/docs/changelog.md
+++ b/site/docs/changelog.md
@@ -1,3 +1,43 @@
+## v1.41.0 — 2026-04-03
+
+### Features — Admin UX and Scheduling
+
+- **Tenants page redesign** — The superadmin tenants page now uses a denser, org-oriented layout for faster scanning across workspaces.
+- **`setup_scheduling` MCP tool** — New idempotent tool that creates `_fyso_schedules`, `_fyso_schedule_exceptions`, and `_fyso_bookings` for a tenant before using scheduling flows.
+- **Org switcher clarity** — Personal orgs you do not own now render as `Personal (Owner Name)` and show role badges in the switcher.
+
+### Fixes — Metadata and MCP
+
+- **Stateless MCP tenant context** — MCP requests that do not carry prior session state now recover the selected tenant context correctly.
+- **Metadata export/import hardening** — `/metadata/export` now keeps the standard JSON envelope for normal responses, negotiates gzip when requested, and `/metadata/import` correctly restores entity rows and nullable custom-field metadata.
+- **Metadata smoke coverage** — Added end-to-end smoke tests for metadata export/import and header negotiation to catch regressions earlier.
+
+### Fixes — Scheduling
+
+- **Scheduling bootstrap and booking race conditions** — New tenants now get the required scheduling entities, missing setup fails with a clear `422`, and slot creation closes a time-of-check/time-of-use race.
+
+---
+
+## v1.40.0 — 2026-04-01
+
+### Features — App Distribution
+
+- **Instance tenant metadata cloning** — Creating an `instance` tenant can now clone metadata from its source standalone tenant.
+- **`mode` and `sourceTenantId` forwarding** — MCP `create_tenant` and `POST /auth/tenants` now forward app-distribution fields consistently during tenant creation.
+
+### Features — Developer Experience
+
+- **Team helper scripts** — Added `lib/start-team` and `lib/team-status` scripts to boot and inspect local multi-agent/dev sessions.
+- **E2E smoke coverage for MCP tool groups** — Added smoke coverage across all documented MCP tool groups to validate live server behavior end to end.
+
+### Fixes
+
+- **`instanceGuard` enforcement** — Schema mutation routes now apply instance-tenant protection consistently in the correct middleware order.
+- **Metadata transport fixes** — Metadata export now respects `Accept-Encoding` for content negotiation, and import fixes handle entity inserts plus nullable `isSystem` values correctly.
+- **Scheduling bootstrap** — Scheduling system entities are seeded on tenant creation so booking flows work on fresh tenants without manual repair.
+- **Landing and messaging polish** — Signup CTAs now route to onboarding, the web app ships a favicon, and agent message hooks guard against undefined thread state.
+
+---
 ## v1.39.0 — 2026-03-29
 
 ### Features — App Distribution

--- a/site/docs/scheduling/availability.md
+++ b/site/docs/scheduling/availability.md
@@ -1,85 +1,156 @@
 # Availability and Schedules
 
-Fyso's scheduling system calculates availability automatically from three entities.
+Fyso's scheduling engine calculates availability from three dedicated system entities:
+
+- `_fyso_schedules`
+- `_fyso_schedule_exceptions`
+- `_fyso_bookings`
+
+These entities are separate from domain entities such as `doctors`, `patients`, or `appointments`.
+
+## Setup
+
+Run `setup_scheduling` once per tenant, or call `POST /api/scheduling/setup`.
+
+The setup is idempotent. It creates and publishes the three `_fyso_*` entities if they do not exist.
 
 ## Required Entities
 
-To use the scheduling system, the tenant must have these three entities:
+### `_fyso_schedules`
 
-### `horarios`
+Regular schedules for each professional.
 
-Defines the regular schedules for each professional.
+| `fieldKey` | `fieldType` | Required | Description |
+|------------|-------------|----------|-------------|
+| `professional_id` | `text` | Yes | UUID of the professional |
+| `rrule` | `text` | Yes | RFC 5545 RRULE string |
+| `start_time` | `text` | No | Start time in `HH:MM`. Defaults to `09:00` if missing |
+| `end_time` | `text` | No | End time in `HH:MM`. Defaults to `17:00` if missing |
+| `slot_duration` | `number` | No | Slot duration in minutes. Defaults to `30` if missing |
+| `active` | `boolean` | No | Whether the schedule is active. Defaults to `true` |
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `profesional_id` | relation | Reference to the professional |
-| `rrule` | text | Recurrence rule (RFC 5545 / RRule format) |
-| `hora_inicio` | text | Start time (HH:MM) |
-| `hora_fin` | text | End time (HH:MM) |
-| `duracion_turno` | number | Duration of each slot in minutes |
-| `activo` | boolean | Whether the schedule is active |
+Example:
 
-Example `rrule`: `RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` (Monday to Friday).
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "rrule": "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR",
+  "start_time": "09:00",
+  "end_time": "13:00",
+  "slot_duration": 30,
+  "active": true
+}
+```
 
-### `excepciones_horario`
+### `_fyso_schedule_exceptions`
 
-Defines exceptions to the regular schedule (holidays, special days).
+Blocked days or special-hours overrides.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `profesional_id` | relation | Reference to the professional |
-| `fecha` | date | Exception date (YYYY-MM-DD) |
-| `tipo` | select | `"bloqueado"` (unavailable) or `"horario_especial"` |
-| `hora_inicio` | text | Start time (only for `horario_especial`) |
-| `hora_fin` | text | End time (only for `horario_especial`) |
+| `fieldKey` | `fieldType` | Required | Description |
+|------------|-------------|----------|-------------|
+| `professional_id` | `text` | Yes | UUID of the professional |
+| `date` | `date` | Yes | Exception date in `YYYY-MM-DD` |
+| `type` | `select` | Yes | `blocked` or `special_hours` |
+| `start_time` | `text` | No | Required when `type = "special_hours"` |
+| `end_time` | `text` | No | Required when `type = "special_hours"` |
 
-### `turnos`
+Blocked-day example:
 
-The booked appointments.
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "date": "2026-05-01",
+  "type": "blocked"
+}
+```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `profesional_id` | relation | Reference to the professional |
-| `paciente_id` | relation | Reference to the patient/client |
-| `fecha` | date | Appointment date (YYYY-MM-DD) |
-| `hora` | text | Appointment time (HH:MM) |
-| `duracion` | number | Duration in minutes |
-| `estado` | select | `"confirmado"`, `"cancelado"`, etc. |
-| `notas` | textarea | Optional notes |
+Special-hours example:
+
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "date": "2026-05-02",
+  "type": "special_hours",
+  "start_time": "10:00",
+  "end_time": "12:00"
+}
+```
+
+### `_fyso_bookings`
+
+Confirmed bookings already taken by the engine into account.
+
+| `fieldKey` | `fieldType` | Required | Description |
+|------------|-------------|----------|-------------|
+| `professional_id` | `text` | Yes | UUID of the professional |
+| `patient_id` | `text` | Yes | UUID of the patient/client |
+| `date` | `date` | Yes | Booking date in `YYYY-MM-DD` |
+| `time` | `text` | Yes | Booking time in `HH:MM` |
+| `duration` | `number` | No | Duration in minutes |
+| `status` | `select` | Yes | `confirmed`, `cancelled`, or `completed` |
+| `notes` | `textarea` | No | Optional notes |
+
+## RRULE Notes
+
+The engine reads recurring days from `rrule`, then combines that with `start_time`, `end_time`, and `slot_duration`.
+
+- `rrule` chooses which dates are active.
+- `start_time` and `end_time` define the time window for each matching date.
+- `slot_duration` defines the size of each generated slot.
+- If `DTSTART` is omitted, the engine prepends one automatically for the query range.
+
+Typical weekday morning schedule:
+
+```text
+FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
+```
+
+Every Monday from 09:00 to 13:00:
+
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "rrule": "FREQ=WEEKLY;BYDAY=MO",
+  "start_time": "09:00",
+  "end_time": "13:00",
+  "slot_duration": 30,
+  "active": true
+}
+```
 
 ## MCP Tool: `get_available_slots`
 
 **Profile:** core
 
-Calculates available slots considering schedules, exceptions, and existing appointments.
+Calculates available slots considering schedules, exceptions, and confirmed bookings.
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `profesional_id` | string | Yes | Professional's UUID |
-| `fecha` | string | No | Specific date (YYYY-MM-DD) |
-| `desde` | string | No | Range start (YYYY-MM-DD) |
-| `hasta` | string | No | Range end (YYYY-MM-DD, max 90 days) |
+| `professional_id` | string | Yes | Professional UUID |
+| `date` | string | No | Specific date in `YYYY-MM-DD` |
+| `from` | string | No | Range start in `YYYY-MM-DD` |
+| `to` | string | No | Range end in `YYYY-MM-DD` |
 
-Provide `fecha` for a single day, or `desde`/`hasta` for a range.
+Provide `date` for a single day, or `from` and `to` for a range. Maximum range: 90 days.
 
 ### Example: Single Day
 
-```
+```js
 get_available_slots({
-  profesional_id: "uuid-del-profesional",
-  fecha: "2026-02-20"
+  professional_id: "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  date: "2026-05-05"
 })
 ```
 
 ### Example: Date Range
 
-```
+```js
 get_available_slots({
-  profesional_id: "uuid-del-profesional",
-  desde: "2026-02-20",
-  hasta: "2026-02-28"
+  professional_id: "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  from: "2026-05-05",
+  to: "2026-05-09"
 })
 ```
 
@@ -87,16 +158,71 @@ get_available_slots({
 
 ```json
 [
-  { "fecha": "2026-02-20", "hora": "09:00", "duracion": 30, "profesional_id": "uuid" },
-  { "fecha": "2026-02-20", "hora": "09:30", "duracion": 30, "profesional_id": "uuid" },
-  { "fecha": "2026-02-20", "hora": "10:00", "duracion": 30, "profesional_id": "uuid" }
+  {
+    "date": "2026-05-05",
+    "time": "09:00",
+    "duration": 30,
+    "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002"
+  },
+  {
+    "date": "2026-05-05",
+    "time": "09:30",
+    "duration": 30,
+    "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002"
+  }
 ]
 ```
 
-### Calculation Logic
+## REST API
 
-1. Gets the active schedules for the professional
-2. Generates slots based on `hora_inicio`, `hora_fin`, and `duracion_turno`
-3. Applies the recurrence rule (`rrule`) to determine which days it applies
-4. Excludes blocked dates and adjusts special schedules
-5. Excludes slots that already have a confirmed appointment
+REST uses the same parameter names as MCP:
+
+```text
+GET /api/scheduling/available-slots?professional_id=<uuid>&date=2026-05-05
+GET /api/scheduling/available-slots?professional_id=<uuid>&from=2026-05-05&to=2026-05-09
+```
+
+## Troubleshooting
+
+### `422 Scheduling entities not found`
+
+The tenant has not been initialized for scheduling yet.
+
+Fix:
+
+```js
+setup_scheduling()
+```
+
+or:
+
+```text
+POST /api/scheduling/setup
+```
+
+### Empty array response
+
+An empty array is valid when:
+
+- the professional has no active schedules
+- the date range has no matching RRULE occurrences
+- all generated slots are blocked by exceptions
+- all generated slots are already booked
+
+### Invalid RRULE
+
+Invalid RRULE strings do not crash the request, but they produce no generated dates. Verify the rule format first.
+
+## Legacy Compatibility
+
+Older tenants may still contain legacy names such as `horarios`, `excepciones_horario`, `turnos`, or field keys like `profesional_id` and `fecha`.
+
+Fyso migrates those legacy system entities to `_fyso_*` names and English field keys. New documentation uses only the current names.
+
+## `clinica` Preset
+
+The `clinica` preset installs domain entities such as `doctors`, `patients`, and `appointments`.
+
+Those entities are not the scheduling engine's storage layer. The engine reads only `_fyso_schedules`, `_fyso_schedule_exceptions`, and `_fyso_bookings`.
+
+If you install `clinica` and want to use `get_available_slots` or `create_booking`, run `setup_scheduling` and model the scheduling data in the `_fyso_*` entities, or add your own synchronization/business-rule layer between domain records and the scheduling system.

--- a/site/docs/scheduling/bookings.md
+++ b/site/docs/scheduling/bookings.md
@@ -4,84 +4,120 @@
 
 **Profile:** core
 
-Creates a booking after validating that the slot is available.
+Creates a booking after validating that the requested slot is available.
+
+The booking is stored in `_fyso_bookings` with `status = "confirmed"`.
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `profesional_id` | string | Yes | Professional's UUID |
-| `paciente_id` | string | Yes | Patient/client UUID |
-| `fecha` | string | Yes | Date (YYYY-MM-DD) |
-| `hora` | string | Yes | Time (HH:MM) |
-| `duracion` | number | No | Duration in minutes. Default: professional's slot duration |
-| `notas` | string | No | Optional notes |
-
-### Internal Flow
-
-1. Queries available slots for the date
-2. Verifies that `fecha + hora` is in the available slots list
-3. If available, creates a record in the `turnos` entity with `estado = "confirmado"`
-4. If not available, returns an error
+| `professional_id` | string | Yes | Professional UUID |
+| `patient_id` | string | Yes | Patient/client UUID |
+| `date` | string | Yes | Date in `YYYY-MM-DD` |
+| `time` | string | Yes | Time in `HH:MM` |
+| `duration` | number | No | Duration in minutes. Defaults to the schedule slot size |
+| `notes` | string | No | Optional notes |
 
 ### Example
 
-```
+```js
 create_booking({
-  profesional_id: "uuid-del-profesional",
-  paciente_id: "uuid-del-paciente",
-  fecha: "2026-02-20",
-  hora: "10:00",
-  notas: "Control de rutina"
+  professional_id: "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  patient_id: "1f8f3577-365a-4e28-aa41-88e8cb4a351e",
+  date: "2026-05-05",
+  time: "10:00",
+  notes: "Routine checkup"
 })
 ```
+
+### Internal Flow
+
+1. Validates request shape and UUID/date/time formats.
+2. Checks whether scheduling entities exist for the tenant.
+3. Computes current availability for the requested slot.
+4. Creates a record in `_fyso_bookings` with `status = "confirmed"` if the slot is still available.
+5. Rejects the request if the slot is missing or already taken.
 
 ### Successful Response
 
 ```json
 {
   "success": true,
-  "message": "Booking created for 2026-02-20 at 10:00",
-  "record": {
-    "id": "uuid-del-turno",
-    "profesional_id": "uuid",
-    "paciente_id": "uuid",
-    "fecha": "2026-02-20",
-    "hora": "10:00",
-    "duracion": 30,
-    "estado": "confirmado",
-    "notas": "Control de rutina"
+  "data": {
+    "id": "uuid-del-booking",
+    "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+    "patient_id": "1f8f3577-365a-4e28-aa41-88e8cb4a351e",
+    "date": "2026-05-05",
+    "time": "10:00",
+    "duration": 30,
+    "status": "confirmed",
+    "notes": "Routine checkup"
   }
 }
 ```
 
-### Error: Slot Not Available
+### Common Errors
+
+Slot not available:
 
 ```json
 {
   "success": false,
-  "error": "Slot 2026-02-20 10:00 is not available for this professional"
+  "error": "Slot 2026-05-05 10:00 is not available for this professional"
 }
 ```
 
-## Cancel an Appointment
+Scheduling not initialized:
 
-There is no dedicated tool for canceling. Update the record directly:
-
-```
-update_record({
-  entityName: "turnos",
-  recordId: "uuid-del-turno",
-  data: { estado: "cancelado" }
-})
+```json
+{
+  "success": false,
+  "error": "Scheduling entities not found. Run setup_scheduling (MCP) or POST /scheduling/setup to initialise _fyso_schedules, _fyso_schedule_exceptions, and _fyso_bookings."
+}
 ```
 
 ## REST API
 
-The REST endpoint for availability:
+Create booking:
 
-```
-GET /api/scheduling/available-slots?profesional_id=uuid&fecha=2026-02-20
+```text
+POST /api/scheduling/bookings
+Authorization: Bearer TOKEN
+Content-Type: application/json
 ```
 
-Headers: `Authorization: Bearer TOKEN`
+Request body:
+
+```json
+{
+  "professional_id": "9d5e3e28-6eb8-49e3-8a34-1a6b7d91f002",
+  "patient_id": "1f8f3577-365a-4e28-aa41-88e8cb4a351e",
+  "date": "2026-05-05",
+  "time": "10:00",
+  "duration": 30,
+  "notes": "Routine checkup"
+}
+```
+
+Availability lookup:
+
+```text
+GET /api/scheduling/available-slots?professional_id=<uuid>&date=2026-05-05
+```
+
+## Cancellation
+
+There is no dedicated cancel-booking tool yet.
+
+To cancel a booking, update the `_fyso_bookings` record and set:
+
+```json
+{ "status": "cancelled" }
+```
+
+## Notes
+
+- `create_booking` uses English parameter names in both MCP and REST.
+- The engine does not write to domain entities such as `appointments`.
+- If your tenant uses the `clinica` preset, treat `_fyso_bookings` as scheduling-engine state and add your own sync to `appointments` if your product flow needs both.

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/admin/import-export.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/admin/import-export.md
@@ -6,7 +6,7 @@ Exportar e importar la estructura (entidades, campos, reglas) de un tenant.
 
 **Perfil:** core
 
-Exporta la metadata del tenant actual a un JSON.
+Exporta la metadata del tenant actual. En MCP, la herramienta devuelve un resumen corto en texto y guarda la exportacion completa en un archivo JSON temporal.
 
 ### Parametros
 
@@ -22,7 +22,14 @@ export_metadata()
 
 ### Respuesta
 
-Retorna un JSON con la estructura completa:
+Retorna un resumen en texto similar a:
+
+```text
+Export completed: 3 entities, 2 rules (18.4 KB)
+Saved to: /tmp/fyso-export-mi-tenant-2026-04-09T21-30-00.json
+```
+
+El archivo guardado contiene la estructura completa de la exportacion:
 
 ```json
 {
@@ -39,11 +46,20 @@ Retorna un JSON con la estructura completa:
 }
 ```
 
+### Comportamiento de la HTTP API
+
+Si llamas directamente a `/metadata/export` en lugar de usar la herramienta MCP:
+
+- Las respuestas normales usan el envelope JSON estandar `{ success, data }`
+- Si el cliente envia `Accept-Encoding: gzip` y el payload supera el umbral, el servidor puede responder con `application/gzip`
+- Las respuestas gzip incluyen los headers `X-Original-Size` y `X-Compressed-Size`
+- Las respuestas JSON y gzip contienen la misma metadata
+
 ## MCP Tool: `import_metadata`
 
 **Perfil:** core
 
-Importa metadata desde un JSON a un tenant.
+Importa metadata a un tenant.
 
 ### Parametros
 
@@ -56,12 +72,18 @@ Importa metadata desde un JSON a un tenant.
 
 ```
 import_metadata({
-  metadata: '{"entities":[...],"version":"1.0"}'
+  metadata: JSON.stringify({
+    version: "1.0",
+    entities: [...],
+    businessRules: [...]
+  })
 })
 ```
 
 ### Notas
 
+- El parametro MCP `metadata` es un string JSON
+- El endpoint HTTP `/metadata/import` acepta tanto un body JSON como un body gzip (`application/gzip` o `Content-Encoding: gzip`)
 - La importacion crea las entidades y campos del sistema (`isSystem=true`)
 - Los campos custom (`isSystem=false`) creados con `manage_custom_fields` NO se ven afectados
 - Si una entidad ya existe, se actualizan sus campos del sistema

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/api/mcp-tools.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/api/mcp-tools.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 Referencia completa de todas las herramientas MCP disponibles.
 
-El servidor MCP expone **10 herramientas agrupadas** (cada una con un parametro `action` tipo enum), mas `fyso_welcome` para onboarding. Configura que herramientas se exponen con la variable de entorno `FYSO_TOOLS`. Ver [Perfiles de herramientas](tool-profiles.md).
+El servidor MCP expone **10 herramientas agrupadas** (cada una con un parametro `action` tipo enum), mas `fyso_welcome` y `setup_scheduling`. Los nombres legacy como `export_metadata` e `import_metadata` siguen despachandose por compatibilidad hacia atras. Configura que herramientas se exponen con la variable de entorno `FYSO_TOOLS`. Ver [Perfiles de herramientas](tool-profiles.md).
 
 ## Como funcionan las herramientas agrupadas
 
@@ -17,6 +17,17 @@ fyso_data({ action: "create", entity: "tasks", data: { title: "Fix bug" } })
 fyso_data({ action: "query", entity: "tasks", filters: "status = open" })
 fyso_auth({ action: "list_tenants" })
 ```
+
+## Herramientas utilitarias standalone
+
+Estas herramientas se anuncian por separado de los routers agrupados:
+
+| Herramienta | Descripcion | Notas |
+|-------------|-------------|-------|
+| `fyso_welcome` | Asistente de onboarding para el primer uso | Sugiere un schema inicial segun el tipo de negocio |
+| `setup_scheduling` | Inicializa las entidades del sistema de scheduling | Ejecutarla una vez en un tenant nuevo antes de `get_slots` o `create_booking` |
+| `export_metadata` | Herramienta legacy compatible para exportar metadata | Ver [Import / Export de metadata](/docs/admin/import-export) |
+| `import_metadata` | Herramienta legacy compatible para importar metadata | Ver [Import / Export de metadata](/docs/admin/import-export) |
 
 ---
 

--- a/site/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
+++ b/site/i18n/es/docusaurus-plugin-content-docs/current/changelog.md
@@ -1,3 +1,44 @@
+## v1.41.0 — 2026-04-03
+
+### Funcionalidades — UX de administracion y scheduling
+
+- **Rediseño de la pagina de tenants** — La pagina de tenants para superadmin ahora usa una vista mas compacta y orientada por organizacion para revisar workspaces mas rapido.
+- **Herramienta MCP `setup_scheduling`** — Nueva herramienta idempotente que crea `_fyso_schedules`, `_fyso_schedule_exceptions` y `_fyso_bookings` antes de usar los flujos de scheduling en un tenant.
+- **Mayor claridad en el selector de organizaciones** — Las organizaciones personales que no te pertenecen ahora se muestran como `Personal (Owner Name)` y exhiben badges de rol en el switcher.
+
+### Correcciones — Metadata y MCP
+
+- **Contexto de tenant en MCP stateless** — Las requests MCP que no traen estado previo de sesion ahora recuperan correctamente el tenant seleccionado.
+- **Endurecimiento de export/import de metadata** — `/metadata/export` conserva el envelope JSON estandar en respuestas normales, negocia gzip cuando corresponde, y `/metadata/import` restaura correctamente filas de entidades y metadata nullable de custom fields.
+- **Cobertura smoke para metadata** — Se agregaron pruebas end-to-end para export/import de metadata y negociacion por headers para detectar regresiones antes.
+
+### Correcciones — Scheduling
+
+- **Bootstrap de scheduling y carreras al reservar** — Los tenants nuevos ahora reciben las entidades requeridas de scheduling, la falta de setup devuelve un `422` claro y la creacion de slots cierra una condicion de carrera TOCTOU.
+
+---
+
+## v1.40.0 — 2026-04-01
+
+### Funcionalidades — App Distribution
+
+- **Clonado de metadata para tenants `instance`** — La creacion de un tenant `instance` ahora puede clonar la metadata desde su tenant standalone de origen.
+- **Forwarding de `mode` y `sourceTenantId`** — MCP `create_tenant` y `POST /auth/tenants` ahora propagan de forma consistente los campos de app distribution durante la creacion del tenant.
+
+### Funcionalidades — Developer Experience
+
+- **Scripts auxiliares de equipo** — Se agregaron `lib/start-team` y `lib/team-status` para iniciar e inspeccionar sesiones locales multi-agent/dev.
+- **Cobertura E2E para grupos de herramientas MCP** — Se agregaron smoke tests sobre todos los grupos de herramientas MCP documentados para validar el comportamiento del servidor en vivo.
+
+### Correcciones
+
+- **Aplicacion consistente de `instanceGuard`** — Las rutas de mutacion de schema ahora aplican la proteccion de tenants instance en el orden correcto de middlewares.
+- **Correcciones de transporte de metadata** — La exportacion de metadata ahora respeta `Accept-Encoding` para la negociacion de contenido, y las correcciones de importacion manejan inserts de entidades y valores nullable en `isSystem`.
+- **Bootstrap de scheduling** — Las entidades del sistema de scheduling se crean al crear un tenant para que los flujos de reservas funcionen en tenants nuevos sin reparacion manual.
+- **Pulido de landing y mensajeria** — Los CTAs de signup ahora van a onboarding, la web incluye favicon y los hooks de mensajes de agentes manejan correctamente estado de thread undefined.
+
+---
+
 ## v1.34.0 — 2026-03-17
 
 ### Funcionalidades


### PR DESCRIPTION
This pull request updates the documentation for Fyso's metadata import/export and scheduling systems, focusing on clarifying API behaviors, standardizing terminology, and providing more detailed setup and usage instructions. The changes improve consistency across docs, modernize field/entity names, and add troubleshooting and compatibility notes for both REST and MCP interfaces.

**Metadata Import/Export Documentation Updates:**

- Clarified the behavior of the MCP export tool: now returns a short text summary and saves the full export to a temporary JSON file, instead of returning the full metadata directly. [[1]](diffhunk://#diff-ca49084363075cb8683c9b0f1ea354b66cd76f6e5d38e0c6672e630ea269b424L9-R9) [[2]](diffhunk://#diff-ca49084363075cb8683c9b0f1ea354b66cd76f6e5d38e0c6672e630ea269b424L25-R32)
- Expanded explanation of the HTTP API: described content negotiation (JSON vs. gzip), response envelopes, and diagnostic headers for large exports. [[1]](diffhunk://#diff-ca49084363075cb8683c9b0f1ea354b66cd76f6e5d38e0c6672e630ea269b424R49-R62) [[2]](diffhunk://#diff-2849a4d4f46d95cb78ce8fc5c561e0e3c0b1b60883bf89830f73ebc2d7cde12bL61-R69) [[3]](diffhunk://#diff-2849a4d4f46d95cb78ce8fc5c561e0e3c0b1b60883bf89830f73ebc2d7cde12bR88-R89)
- Updated import tool documentation to clarify accepted formats (JSON string or gzip) and that the MCP action delegates to the legacy import tool. [[1]](diffhunk://#diff-ca49084363075cb8683c9b0f1ea354b66cd76f6e5d38e0c6672e630ea269b424L59-R86) [[2]](diffhunk://#diff-2849a4d4f46d95cb78ce8fc5c561e0e3c0b1b60883bf89830f73ebc2d7cde12bR88-R89)
- Noted that legacy tool names (`export_metadata`, `import_metadata`) are still supported for backward compatibility, and documented new standalone utility tools in the MCP tool list. [[1]](diffhunk://#diff-2ab9ba485318581c481155702cec74ba52ce079486a75fba978c630de9e4169aL5-R5) [[2]](diffhunk://#diff-2ab9ba485318581c481155702cec74ba52ce079486a75fba978c630de9e4169aR17-R28) [[3]](diffhunk://#diff-0e00b1a210c4f3c41f1319642e18427b204d87f8bfe125813cf3592f5a925447L9-R9) [[4]](diffhunk://#diff-0e00b1a210c4f3c41f1319642e18427b204d87f8bfe125813cf3592f5a925447R21-R32)
- Added English-language documentation mirroring these changes for the site docs. [[1]](diffhunk://#diff-2849a4d4f46d95cb78ce8fc5c561e0e3c0b1b60883bf89830f73ebc2d7cde12bR52-R53) [[2]](diffhunk://#diff-2849a4d4f46d95cb78ce8fc5c561e0e3c0b1b60883bf89830f73ebc2d7cde12bL61-R69) [[3]](diffhunk://#diff-2849a4d4f46d95cb78ce8fc5c561e0e3c0b1b60883bf89830f73ebc2d7cde12bR88-R89)

**Scheduling System Documentation Overhaul:**

- Standardized all scheduling entity and field names to the new system (`_fyso_schedules`, `_fyso_schedule_exceptions`, `_fyso_bookings`, with English field keys like `professional_id`, `date`, `time`, etc.) and provided detailed schema tables and JSON examples for each.
- Added a clear setup section for initializing scheduling entities (`setup_scheduling` tool or REST endpoint), with troubleshooting for common errors like missing entities.
- Updated the booking creation flow: clarified internal validation steps, parameter names, and error handling, and provided detailed REST/MCP examples.
- Documented legacy compatibility: how old tenants with legacy entity/field names are migrated, and how to handle domain entities (`appointments`, etc.) alongside the new scheduling system. [[1]](diffhunk://#diff-83c80e99faca7fddbae40c09c761186092a33ddc9d392722b6309304505aec5dL3-R228) [[2]](diffhunk://#diff-945c8dab8f79b4454cb1923308320b533c866bccd26e56d3ef69ec7ca92152faL1-R123)
- Added sections for REST API usage, error troubleshooting, and notes on canceling bookings (currently requires direct record update). [[1]](diffhunk://#diff-945c8dab8f79b4454cb1923308320b533c866bccd26e56d3ef69ec7ca92152faL1-R123) [[2]](diffhunk://#diff-83c80e99faca7fddbae40c09c761186092a33ddc9d392722b6309304505aec5dL3-R228)

These updates ensure the documentation is accurate, modern, and easier to follow for both new and existing tenants.