### PR TITLE
docs: add Paddle webhook observability guide

### DIFF
--- a/site/docs/billing/paddle-webhook-observability.md
+++ b/site/docs/billing/paddle-webhook-observability.md
@@ -1,0 +1,265 @@
+---
+title: Paddle Webhook Observability
+sidebar_position: 4
+---
+
+# Paddle Webhook Observability
+
+Fyso records inbound Paddle webhook deliveries so superadmins and support operators can
+diagnose payment, subscription, and app-entitlement incidents without reading raw server logs.
+
+This observability layer is separate from `paddle_webhook_events`, which remains the
+idempotency ledger for processed app-entitlement events. The ingress log records every
+request that reaches `POST /api/webhooks/paddle`, including missing signatures, invalid
+signatures, valid billing events, and valid app-entitlement events.
+
+## What Is Logged
+
+The public Paddle webhook endpoint records metadata in `paddle_webhook_ingress_logs`.
+Migration `0088_create_paddle_webhook_ingress_logs.sql` creates the table and indexes the
+fields used by the support views.
+
+| Field | Description |
+|-------|-------------|
+| `route` | Webhook route, currently `/api/webhooks/paddle` |
+| `event_id`, `event_type`, `notification_id` | Paddle event identifiers when available |
+| `scope` | `data.custom_data.scope`, for example `app_entitlement` |
+| `signature_status` | `missing`, `invalid`, or `valid` |
+| `handler` | `none`, `app_entitlement`, `billing`, or `ignored` |
+| `http_status` | Response status returned to Paddle |
+| `error` | Ingress or handler error captured during processing |
+| `org_id`, `source_tenant_id`, `app_key` | App-entitlement context from `custom_data` |
+| `customer_id`, `subscription_id`, `transaction_id` | Paddle object identifiers |
+| `payload` | Persisted for valid billing and app-entitlement events |
+| `received_at` | Ingress timestamp |
+
+The record step is non-blocking for the webhook delivery: if the ingress log insert fails,
+the webhook handler logs the persistence error and continues processing the delivery.
+
+## Delivery Outcomes
+
+| Delivery | `signature_status` | `handler` | Response | Notes |
+|----------|--------------------|-----------|----------|-------|
+| Missing `paddle-signature` header | `missing` | `none` | `400` | No event payload is trusted. |
+| Body read failure | `invalid` | `none` | `400` | Logged before Paddle signature verification. |
+| HMAC verification failure | `invalid` | `none` | `400` | Parsed JSON context is logged if the body can be parsed. |
+| Valid signature, invalid JSON | `valid` | `none` | `400` | Signature passed, but the raw body is not usable JSON. |
+| `custom_data.scope = "app_entitlement"` | `valid` | `app_entitlement` | `200` | Handler errors are captured in `error`; Paddle still receives `200`. |
+| Other normalized Paddle event | `valid` | `billing` | `200` | Uses the existing billing handler. |
+| Valid request with no normalized event | `valid` | `ignored` | `200` | Logged for diagnostics. |
+
+After HMAC verification succeeds, Fyso returns `200` even when business processing fails.
+Those failures should be investigated from the ingress log and `paddle_webhook_events.processing_error`,
+not by waiting for Paddle retries.
+
+## Superadmin Console
+
+Open the superadmin console and go to **Paddle Webhooks**:
+
+```text
+/superadmin/paddle-webhooks
+```
+
+The page is only available to superadmins. It displays:
+
+- Total deliveries.
+- Valid signed deliveries.
+- Rejected deliveries split by invalid and missing signatures.
+- Deliveries with ingress or processing errors.
+- Latest delivery cards with event type, event ID, timestamp, signature status, handler,
+  HTTP status, app context, Paddle IDs, and error text.
+
+### Console Filters
+
+| Filter | Values | Notes |
+|--------|--------|-------|
+| Search | Free text | Searches event ID, notification ID, customer ID, subscription ID, transaction ID, org ID, and source tenant ID. |
+| Signature status | `valid`, `invalid`, `missing` | Empty value shows all signatures. |
+| Handler | `app_entitlement`, `billing`, `ignored`, `none` | Empty value shows all handlers. |
+
+Use the search box with the Paddle `event_id`, `subscription_id`, `transaction_id`, or
+customer ID from a support ticket. Combine it with `handler = app_entitlement` when the
+incident is about Fyso Teams access.
+
+## Superadmin API
+
+The console calls the superadmin API:
+
+```http
+GET /api/admin/platform/paddle-webhooks
+Authorization: Bearer <superadmin-session-token-or-fyso_sa_key>
+```
+
+`X-Admin-Secret: <ADMIN_SECRET>` is still accepted as a legacy fallback where configured.
+
+### Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | number | `1` | Page number. Values below `1` fall back to `1`. |
+| `limit` | number | `50` | Page size. Maximum `100`. |
+| `signatureStatus` | string | none | One of `valid`, `invalid`, `missing`. Invalid values are ignored. |
+| `handler` | string | none | One of `app_entitlement`, `billing`, `ignored`, `none`. Invalid values are ignored. |
+| `eventType` | string | none | Exact event type filter, for example `subscription.created`. |
+| `q` | string | none | Free-text search across Paddle and Fyso context IDs. |
+
+Example:
+
+```bash
+curl "https://api.fyso.dev/api/admin/platform/paddle-webhooks?limit=50&signatureStatus=valid&handler=app_entitlement&q=sub_01h" \
+  -H "Authorization: Bearer fyso_sa_..."
+```
+
+Response shape:
+
+```json
+{
+  "success": true,
+  "data": {
+    "logs": [
+      {
+        "id": "log-uuid",
+        "route": "/api/webhooks/paddle",
+        "event_id": "evt_01h...",
+        "event_type": "subscription.created",
+        "notification_id": "ntf_01h...",
+        "scope": "app_entitlement",
+        "signature_status": "valid",
+        "handler": "app_entitlement",
+        "http_status": 200,
+        "error": null,
+        "processing_error": null,
+        "org_id": "org-uuid",
+        "source_tenant_id": "65422493-73d8-4e74-a879-defa3a9771f1",
+        "app_key": "fyso_teams",
+        "customer_id": "ctm_01h...",
+        "subscription_id": "sub_01h...",
+        "transaction_id": null,
+        "received_at": "2026-05-02T16:07:49.002Z"
+      }
+    ],
+    "summary": {
+      "totalLogs": 1,
+      "validCount": 1,
+      "invalidSignatureCount": 0,
+      "missingSignatureCount": 0,
+      "appEntitlementCount": 1,
+      "billingCount": 0,
+      "errorCount": 0
+    },
+    "pagination": {
+      "page": 1,
+      "limit": 50,
+      "total": 1
+    }
+  }
+}
+```
+
+## Support Replay For App Entitlements
+
+Use the support replay script only when support has confirmed that a Paddle subscription
+exists but Fyso did not activate the app entitlement. The script builds and signs an
+`app_entitlement` Paddle event, resolves the target org from an admin email, and posts to
+the same public webhook route.
+
+By default it is a dry run. It prints the resolved org, source tenant, event ID, and payload
+context without sending the webhook.
+
+```bash
+PADDLE_WEBHOOK_SECRET="..." \
+SUPPORT_ACCOUNT_EMAIL="customer@example.com" \
+SUPPORT_PADDLE_SUBSCRIPTION_ID="sub_01h..." \
+SUPPORT_PADDLE_CUSTOMER_ID="ctm_01h..." \
+SUPPORT_PERIOD_END="2026-06-01T00:00:00.000Z" \
+bun run --cwd packages/api support:replay-app-entitlement
+```
+
+Send the replay only after reviewing the dry-run output:
+
+```bash
+PADDLE_WEBHOOK_SECRET="..." \
+SUPPORT_ACCOUNT_EMAIL="customer@example.com" \
+SUPPORT_PADDLE_SUBSCRIPTION_ID="sub_01h..." \
+SUPPORT_PADDLE_CUSTOMER_ID="ctm_01h..." \
+SUPPORT_PERIOD_END="2026-06-01T00:00:00.000Z" \
+bun run --cwd packages/api support:replay-app-entitlement --send
+```
+
+Optional variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PADDLE_WEBHOOK_URL` | `https://api.fyso.dev/api/webhooks/paddle` | Target webhook URL. |
+| `PADDLE_REPLAY_SEND` | unset | Set to `1` as an alternative to `--send`. |
+| `SUPPORT_ORG_ID` | unset | Required when the admin email belongs to multiple orgs. |
+| `SUPPORT_APP_KEY` | `fyso_teams` | App key used to resolve `source_tenant_id`. |
+| `SUPPORT_SOURCE_TENANT_ID` | app catalog lookup | Explicit source tenant ID override. |
+| `SUPPORT_EVENT_TYPE` | `subscription.created` | Must be `subscription.created` or `subscription.trialing`. |
+| `SUPPORT_SUBSCRIPTION_STATUS` | `trialing` | Subscription status written into the replay payload. |
+| `SUPPORT_PERIOD_START` | current timestamp | Current billing period start. |
+| `SUPPORT_EVENT_ID` | generated | Explicit event ID for traceability. |
+
+After sending, confirm the replay in **Paddle Webhooks** by searching the generated
+`event_id`, subscription ID, or customer ID. The delivery should show:
+
+- `signature_status = valid`
+- `handler = app_entitlement`
+- `http_status = 200`
+- no ingress `error`
+- no `processing_error`
+
+## Manual Fyso Teams Payment Smoke
+
+The manual smoke test is opt-in and skipped unless `FYSO_TEAMS_PAYMENT_SMOKE=1`.
+Use it during staging or production diagnosis to verify public routes, app catalog config,
+webhook tables, authenticated entitlement reads, and optionally real Paddle checkout creation.
+
+Minimal route/config smoke:
+
+```bash
+FYSO_TEAMS_PAYMENT_SMOKE=1 \
+bun run --cwd packages/api smoke:fyso-teams-payment
+```
+
+Read-only database diagnostics:
+
+```bash
+FYSO_TEAMS_PAYMENT_SMOKE=1 \
+FYSO_TEAMS_SMOKE_DATABASE_URL="postgresql://readonly:...@localhost:5460/fyso?sslmode=prefer" \
+FYSO_TEAMS_SMOKE_TARGET_EMAIL="customer@example.com" \
+bun run --cwd packages/api smoke:fyso-teams-payment
+```
+
+Authenticated entitlement diagnostics:
+
+```bash
+FYSO_TEAMS_PAYMENT_SMOKE=1 \
+FYSO_TEAMS_SMOKE_EMAIL="smoke@example.com" \
+FYSO_TEAMS_SMOKE_PASSWORD="..." \
+bun run --cwd packages/api smoke:fyso-teams-payment
+```
+
+Creating a real Paddle transaction is intentionally separate:
+
+```bash
+FYSO_TEAMS_PAYMENT_SMOKE=1 \
+FYSO_TEAMS_SMOKE_CREATE_CHECKOUT=1 \
+FYSO_TEAMS_SMOKE_EMAIL="smoke@example.com" \
+FYSO_TEAMS_SMOKE_PASSWORD="..." \
+bun run --cwd packages/api smoke:fyso-teams-payment
+```
+
+Additional variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FYSO_TEAMS_SOURCE_ID` | Fyso Teams source tenant UUID | Source app under test. |
+| `FYSO_TEAMS_SMOKE_API_URL` | `https://api.fyso.dev/api` | Direct API base. |
+| `FYSO_TEAMS_SMOKE_WORLD_URL` | `https://fyso.world` | Proxy host smoke target. |
+| `FYSO_TEAMS_SMOKE_AUTH_API_URL` | `${FYSO_TEAMS_SMOKE_WORLD_URL}/api` | Authenticated API base. |
+| `FYSO_TEAMS_SMOKE_EXPECT_ACTIVE_ENTITLEMENT` | unset | Set to `1` to assert the target has an active entitlement. |
+| `FYSO_TEAMS_SMOKE_EXPECT_WEBHOOK_EVENTS` | unset | Set to `1` to assert Fyso Teams webhook events exist. |
+
+Do not enable `FYSO_TEAMS_SMOKE_CREATE_CHECKOUT=1` unless the account and Paddle
+environment are intended to create a real checkout transaction.

--- a/site/docs/billing/stripe.md
+++ b/site/docs/billing/stripe.md
@@ -1,6 +1,8 @@
 # Stripe and Payments
 
-Fyso billing is managed through Stripe.
+Fyso supports provider-specific billing flows. This page covers the Stripe subscription
+flow. For Paddle webhook diagnostics and the superadmin ingress log, see
+[Paddle Webhook Observability](./paddle-webhook-observability.md).
 
 ## Subscription Flow
 

--- a/site/docs/changelog.md
+++ b/site/docs/changelog.md
@@ -1,3 +1,16 @@
+## v1.43.2 — 2026-05-02
+
+### Feature — Paddle Webhook Observability
+
+- **Paddle ingress logs** — `POST /api/webhooks/paddle` now records every delivery that reaches the route, including missing signatures, invalid signatures, valid billing events, and valid app-entitlement events. Logs capture signature status, selected handler, HTTP status, Paddle IDs, Fyso org/app context, timestamps, and handler errors.
+- **Superadmin Paddle Webhooks page** — `/superadmin/paddle-webhooks` shows delivery totals, signed/rejected/error summaries, latest deliveries, app context, Paddle IDs, and error details for support triage.
+- **Superadmin API filters** — `GET /api/admin/platform/paddle-webhooks` supports pagination plus `signatureStatus`, `handler`, `eventType`, and free-text `q` filters. Search covers event, notification, customer, subscription, transaction, org, and source tenant IDs.
+- **Support tooling** — Added `support:replay-app-entitlement` for dry-run-first signed app-entitlement webhook replay, and `smoke:fyso-teams-payment` for opt-in Fyso Teams payment diagnostics.
+
+See [Paddle Webhook Observability](/docs/billing/paddle-webhook-observability) for the full operator guide.
+
+---
+
 ## v1.41.0 — 2026-04-03
 
 ### Features — Admin UX and Scheduling

--- a/site/docs/intro.md
+++ b/site/docs/intro.md
@@ -44,4 +44,4 @@ If you prefer the web panel or want to understand how things work:
 | [Deployment](deployment/static-sites.md) | Static sites, GitHub Actions, custom domains |
 | [PDF](pdf/generation.md) | Templates and document generation |
 | [Scheduling](scheduling/availability.md) | Availability, bookings, schedules |
-| [Billing](billing/plans.md) | Plans, limits, storage usage |
+| [Billing](billing/plans.md) | Plans, limits, storage usage, payment provider diagnostics |

--- a/site/scripts/generate-llms-full.mjs
+++ b/site/scripts/generate-llms-full.mjs
@@ -82,6 +82,7 @@ const FILES = [
   // Billing
   'billing/plans.md',
   'billing/storage-usage.md',
+  'billing/paddle-webhook-observability.md',
   'billing/stripe.md',
   // Changelog & intro
   'changelog.md',

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -102,6 +102,7 @@
 
 - [Plans and Limits](https://docs.fyso.dev/docs/billing/plans): Free, Pro, Beta, Enterprise — limits, rate limits, quotas
 - [Storage Usage](https://docs.fyso.dev/docs/billing/storage-usage): DB, knowledge base, bucket breakdown
+- [Paddle Webhook Observability](https://docs.fyso.dev/docs/billing/paddle-webhook-observability): Superadmin Paddle ingress logs, filters, support replay, manual payment smoke
 - [Stripe](https://docs.fyso.dev/docs/billing/stripe): Subscription flow, customer portal, webhooks
 
 ## Optional


### PR DESCRIPTION
## Summary

- Adds a new Billing guide for Paddle webhook observability: ingress log fields, delivery outcomes, superadmin console filters, and the superadmin API response shape.
- Documents operator workflows for dry-run-first app-entitlement support replay and opt-in Fyso Teams payment smoke checks.
- Updates the Stripe billing page, intro, changelog, llms index, and llms-full generator to surface the new guide.

## Source verification

Verified against merged backend source on `origin/develop`:
- PR fyso-dev/fyso_backend#1535 commit `676a6b6a`.
- `packages/api/src/routes/billing.ts` records missing, invalid, valid billing, and valid app-entitlement Paddle webhook deliveries.
- `packages/api/src/services/paddle-webhook-ingress.service.ts` implements filters and summary counts.
- `packages/db/migrations/0088_create_paddle_webhook_ingress_logs.sql` defines the ingress log table and indexes.
- `packages/web/src/app/superadmin/paddle-webhooks/page.tsx` exposes the superadmin page and UI filters.
- `packages/api/src/scripts/support-replay-app-entitlement-webhook.ts` and `fyso-teams-payment-smoke.manual.test.ts` define the documented support commands.

## Tests

- `npm ci`
- `npx tsc --noEmit`
- `npm run build`

Build completed successfully. Existing Docusaurus warnings remain for historical navbar/footer category links and pre-existing relative doc links; this PR did not introduce new broken links.

## Notes

The docs repository has no `develop` branch, so this PR targets `main`.

Closes fyso-dev/fyso_backend#1539