### PR TITLE
Add agent awareness framework docs

### DIFF
--- a/site/docs/agents/agent-awareness-framework.md
+++ b/site/docs/agents/agent-awareness-framework.md
@@ -1,0 +1,147 @@
+---
+sidebar_position: 11
+---
+
+# Agent Awareness Framework
+
+The Agent Awareness Framework is a working methodology for humans who use several AI coding agents across parallel tasks. It is not a product feature, a task runner, or a replacement for Jira. Its purpose is to make agent work traceable enough that a human can reconstruct the day, produce accurate worklogs, and hand work from one agent session to another without relying on hidden model memory.
+
+## Scope
+
+Version the methodology, not the private state.
+
+| Artifact | Location | Versioned? | Purpose |
+|----------|----------|------------|---------|
+| Framework docs | Shared documentation repository | Yes | Canonical operating rules, templates, evaluation rubric |
+| Agent instructions | User or repo agent config | Optional | Small entrypoint that points agents to the framework |
+| Awareness board | Local private file | No | Mutable current state for active, paused, blocked, and waiting tasks |
+| Daily worklog | Local private file | No | Append-only chronological evidence of the day |
+| Personal memory | Local private file or managed memory store | No | Preferences, durable facts, and repeated context |
+
+Real `awareness`, `worklog`, and personal memory files must stay outside version control. Only sanitized templates and rules belong in the repository.
+
+## Operating Principles
+
+1. Keep operational state explicit. Agents should read the current private awareness file before acting and should update it when focus, blockers, or task state changes.
+2. Keep history append-only. A daily worklog is the chronological record; corrections are new entries, not rewrites.
+3. Keep the live board small. The awareness file should contain the current working set, not the full history of the week.
+4. Tie work to external IDs when available. If a Jira issue, GitHub issue, or PR exists, record it. Do not invent identifiers.
+5. Record evidence, not narration. Prefer file paths, commands, test results, PR links, commit hashes, and blocker details.
+6. Separate framework improvement from daily execution. Agents may propose methodology changes, but changes to the framework are reviewed through normal version control.
+7. Require human confirmation before writing to external systems. Daily summaries can be prepared automatically, but Jira worklogs, comments, status transitions, and public updates should be confirmed.
+
+## Lifecycle
+
+### 1. Initialization
+
+At the start of a session, the agent reads the private awareness board and identifies:
+
+- current focus
+- active and paused tasks
+- blockers and waiting states
+- task IDs related to the user's request
+- the expected next action
+
+If the user's request conflicts with the current focus, the agent records a task switch before continuing.
+
+### 2. Task Start
+
+When a task starts, the agent creates or updates a task block in the awareness board with:
+
+- task ID or `Unassigned`
+- repository, branch, or workspace
+- state
+- next action
+- blockers, if any
+- evidence collected so far
+
+The daily worklog receives a short start entry.
+
+### 3. Progress
+
+The agent appends to the worklog after concrete progress:
+
+- files created or changed
+- tests, builds, or checks run
+- commits, PRs, or deployment actions
+- decisions that affect implementation
+- blockers or handoff points
+
+The awareness board is updated when the task state changes, not after every minor edit.
+
+### 4. Task Switch
+
+When switching tasks, the agent marks the previous task as `paused`, `blocked`, `waiting`, or `done`, then makes the new task the current focus. The worklog records the switch with both task IDs when available.
+
+This is the core support for parallel work: only one `Current Focus` exists, but many tasks can remain active or paused with an explicit next action.
+
+### 5. Handoff
+
+Before returning control to the user, the agent ensures the awareness board answers:
+
+- What is the current focus?
+- What changed?
+- What evidence exists?
+- What remains next?
+- What is blocked or waiting?
+- Which entries are candidates for end-of-day reporting?
+
+The final worklog entry should make the handoff reconstructable without reading the whole chat transcript.
+
+### 6. End of Day
+
+At the end of the day, the agent prepares a grouped summary from the daily worklog:
+
+- by Jira issue or external task ID
+- by repository or workspace
+- by outcome
+- with evidence links or command results
+- with unresolved blockers
+
+The user reviews and confirms any external posting.
+
+## Parallel Task Model
+
+Use the awareness board as a compact state index:
+
+| Section | Meaning |
+|---------|---------|
+| Current Focus | The one task the current agent session is actively serving |
+| Active Tasks | Work that can continue without waiting on external input |
+| Blocked Tasks | Work that cannot progress and why |
+| Waiting On User | Decisions, credentials, approvals, or clarifications needed from a human |
+| Parking Lot | Relevant but intentionally deferred ideas |
+| End-of-Day Candidates | Items likely to become Jira worklog or status-report material |
+
+For parallel work, each task block should carry a short `Next` field. If the next action is not clear, the task is not ready for handoff.
+
+## Relationship to Task Managers
+
+This framework can coexist with Jira, GitHub issues, Taskmaster-style project task files, or sprint boards.
+
+- Use Jira or GitHub as the external planning and accountability system.
+- Use project task managers for decomposition inside a repo.
+- Use the awareness board for immediate cross-agent operational state.
+- Use the daily worklog for chronological evidence and end-of-day reporting.
+
+The framework should not duplicate every field from external task systems. It stores only the context needed for the next agent session and the final worklog.
+
+## Implementation Notes
+
+Recommended private local layout:
+
+```text
+~/.agents/
+  AGENTS.md
+  awareness/
+    current.md
+  worklog/
+    YYYY-MM-DD.md
+  memory/
+    preferences.md
+    patterns.md
+```
+
+Agent-specific instruction files can be thin wrappers that point to the canonical private `AGENTS.md`. Prefer regular wrapper files over symlinks when a CLI, sandbox, sync engine, or editor may not resolve links consistently.
+
+See [Awareness and Worklog Templates](./awareness-worklog-templates.md) for sanitized templates and [Evaluation and Self-Improvement Loop](./awareness-evaluation-loop.md) for the improvement process.

--- a/site/docs/agents/awareness-evaluation-loop.md
+++ b/site/docs/agents/awareness-evaluation-loop.md
@@ -1,0 +1,143 @@
+---
+sidebar_position: 13
+---
+
+# Evaluation and Self-Improvement Loop
+
+The framework should improve from daily use, but it should not mutate itself silently. Self-improvement means the agent observes friction, scores the process, proposes changes, and opens a reviewed documentation change when the improvement is justified.
+
+## Improvement Boundary
+
+| May happen automatically | Requires human review |
+|--------------------------|-----------------------|
+| Generate a daily evaluation note | Change the versioned framework |
+| Detect stale awareness state | Post worklogs to Jira or external tools |
+| Suggest better templates | Merge methodology changes |
+| Flag noisy or missing fields | Store new durable personal memory |
+| Prepare an improvement PR | Apply organization-wide rules |
+
+This keeps the loop useful without letting local mistakes become global policy.
+
+## Cadence
+
+| Cadence | Evaluation |
+|---------|------------|
+| Task switch | Was the previous task left with a clear state and next action? |
+| Session handoff | Can another agent continue from the awareness board and worklog? |
+| End of day | Can the day be summarized by task ID with evidence? |
+| Weekly | Did recurring failures justify a template or rule change? |
+
+## Signals to Track
+
+Track process quality from the private worklog and awareness board:
+
+- stale `Current Focus`
+- active tasks without `Next`
+- worklog entries without task IDs
+- worklog entries without evidence
+- repeated blockers with no owner or next checkpoint
+- external task IDs discovered late
+- chat-only decisions not reflected in the worklog
+- excessive detail that makes the awareness board expensive to read
+- end-of-day summary edits caused by missing context
+
+## Scoring Rubric
+
+Use a small rubric so evaluation stays cheap.
+
+| Dimension | 0 | 1 | 2 |
+|-----------|---|---|---|
+| Freshness | Awareness state is stale or misleading | Mostly current, with minor gaps | Current focus and task states are accurate |
+| Traceability | Work cannot be tied to task IDs or evidence | Some work is traceable | Most meaningful work has task ID and evidence |
+| Handoff quality | Another agent would need chat history | Next actions exist but lack context | Another agent can continue from files alone |
+| Noise control | Files are too verbose or obsolete | Some cleanup needed | Current board is compact and useful |
+| External reporting | End-of-day summary needs reconstruction | Summary exists with manual fixes | Summary is ready for human review |
+
+Scores are diagnostic, not performance ratings. A low score should produce a targeted improvement proposal.
+
+## Daily Evaluation Template
+
+```markdown
+# Awareness Evaluation - YYYY-MM-DD
+
+## Score
+
+| Dimension | Score | Evidence |
+|-----------|-------|----------|
+| Freshness | 0-2 | What was current or stale |
+| Traceability | 0-2 | Missing or present task IDs/evidence |
+| Handoff quality | 0-2 | Whether next actions were clear |
+| Noise control | 0-2 | What should be trimmed |
+| External reporting | 0-2 | How much rewrite was needed |
+
+## Observations
+
+- What worked well enough to keep
+- What caused missing context or duplicate effort
+- What should be changed in templates or rules
+
+## Proposed Changes
+
+- No change
+- Local habit change
+- Template adjustment
+- Framework documentation PR
+```
+
+## Weekly Improvement Process
+
+1. Review daily evaluation notes and identify recurring issues.
+2. Group issues into one of three buckets: local habit, template gap, or framework rule gap.
+3. Promote a change only when the same issue appears repeatedly or causes material rework.
+4. Prefer removing or simplifying fields before adding more fields.
+5. Open a documentation PR for framework changes.
+6. Keep private examples redacted or synthetic.
+
+## Change Proposal Template
+
+```markdown
+# Framework Improvement Proposal
+
+## Problem
+
+What repeated failure or costly handoff issue was observed?
+
+## Evidence
+
+- Dates or redacted examples
+- Missing worklog fields
+- Stale awareness states
+- Rework caused during end-of-day reporting
+
+## Proposed Change
+
+The smallest rule, template, or lifecycle change that addresses the issue.
+
+## Expected Effect
+
+How the change improves traceability, handoff, or reporting.
+
+## Rollback Criteria
+
+When the change should be removed or softened because it adds noise.
+```
+
+## Decision Rules
+
+- Add a rule only when a repeated failure cannot be solved by a local habit.
+- Add a field only when it improves handoff or end-of-day reporting.
+- Remove fields that agents fill with low-value boilerplate.
+- Convert repeated user corrections into template improvements.
+- Keep the current board optimized for the next action, not for historical completeness.
+- Keep the worklog optimized for evidence, not for prose.
+- Change the framework through pull requests, not through hidden local edits.
+
+## Example Outcomes
+
+| Observation | Improvement |
+|-------------|-------------|
+| Many entries say `Unassigned` but later map to Jira | Add an end-of-day prompt to reconcile unassigned entries |
+| Blockers remain stale for days | Add `Since` and `Needed to unblock` to blocked tasks |
+| Awareness board grows too large | Add an end-of-day cleanup step |
+| Test evidence is often missing | Add `Evidence` to the worklog required fields |
+| Agents over-log trivial actions | Clarify that only concrete progress and state changes need entries |

--- a/site/docs/agents/awareness-worklog-templates.md
+++ b/site/docs/agents/awareness-worklog-templates.md
@@ -1,0 +1,187 @@
+---
+sidebar_position: 12
+---
+
+# Awareness and Worklog Templates
+
+These templates define the private files used by the Agent Awareness Framework. Do not commit real instances of these files. They may contain client names, task details, repository paths, decisions, credentials context, or personal working patterns.
+
+## Private File Layout
+
+```text
+~/.agents/
+  AGENTS.md
+  awareness/
+    current.md
+  worklog/
+    2026-06-18.md
+  memory/
+    preferences.md
+    patterns.md
+```
+
+The repository should contain only sanitized templates, examples, and rules.
+
+## Canonical Agent Instructions Template
+
+Use this as the canonical private instruction file and adapt it for each agent CLI.
+
+```markdown
+# Agent Awareness and Worklog Protocol
+
+You operate in a multi-task, multi-agent environment. Before doing work, read the private awareness board and maintain the private daily worklog.
+
+## Required Files
+
+- Awareness board: `~/.agents/awareness/current.md`
+- Daily worklog: `~/.agents/worklog/YYYY-MM-DD.md`
+- Optional durable memory: `~/.agents/memory/`
+
+## Lifecycle
+
+1. On session start, read the awareness board.
+2. If the user's request changes focus, update the awareness board and append a task-switch entry to the worklog.
+3. When concrete progress happens, append to the daily worklog.
+4. When state changes, update the awareness board.
+5. Before handoff, make the awareness board reflect the exact current state and append a final worklog entry.
+
+## Rules
+
+- Keep the worklog append-only.
+- Do not invent task IDs.
+- Record evidence: paths, commands, test results, commits, PRs, deployments, blockers.
+- Keep private state out of version control.
+- Ask before posting worklogs, comments, status changes, or summaries to external systems.
+```
+
+## CLI Wrapper Template
+
+Each agent CLI can have a small regular file that points to the canonical private instructions. Use the import syntax supported by that CLI when available; otherwise, make the wrapper instruct the agent to read the canonical file.
+
+```markdown
+# Local Agent Instructions
+
+Read and follow the canonical private protocol at:
+
+@/Users/example/.agents/AGENTS.md
+
+If your CLI does not expand `@` imports automatically, open that file explicitly before starting work.
+```
+
+Keep wrappers small. The framework should live in the versioned documentation; the local operational rules should live in the canonical private file.
+
+## Awareness Board Template
+
+```markdown
+# Agent Awareness
+
+- Updated: YYYY-MM-DD HH:MM TZ
+- Operator: Human or agent identifier
+- Scope: Local private state; do not commit
+
+## Current Focus
+
+- Task: PROJECT-123 or Unassigned
+- Summary: Short task description
+- Repository: org/repo or local path
+- Branch: branch-name
+- State: in-progress
+- Next: The next concrete action
+
+## Active Tasks
+
+### PROJECT-123 - Short title
+
+- State: in-progress | paused | ready
+- Last update: YYYY-MM-DD HH:MM TZ
+- Repository: org/repo
+- Branch: branch-name
+- Done:
+  - Concrete completed item
+- Next:
+  - Concrete next action
+- Blockers:
+  - None
+- Evidence:
+  - File paths, command results, commit hashes, PR links
+
+## Blocked Tasks
+
+### PROJECT-456 - Short title
+
+- Blocked by: Missing approval, failing dependency, access issue
+- Since: YYYY-MM-DD HH:MM TZ
+- Needed to unblock: Specific action or decision
+- Evidence:
+  - Link or command output
+
+## Waiting On User
+
+- PROJECT-789: Decision needed
+
+## Parking Lot
+
+- Idea or follow-up that should not interrupt current work
+
+## End-of-Day Candidates
+
+- PROJECT-123: Summary candidate with evidence
+```
+
+## Daily Worklog Template
+
+The daily worklog is append-only. Corrections are new entries.
+
+```markdown
+# Daily Worklog - YYYY-MM-DD
+
+## Entries
+
+### HH:MM - PROJECT-123 - Short action summary
+
+- Context: Repository, branch, workspace, or meeting context
+- State: started | in-progress | paused | blocked | done
+- Changes: What changed or was decided
+- Evidence: Paths, command outputs, test results, commit hashes, PR links
+- Next: Optional next action
+```
+
+## End-of-Day Summary Template
+
+```markdown
+# End-of-Day Summary - YYYY-MM-DD
+
+## By Task
+
+### PROJECT-123 - Short title
+
+- Time window: HH:MM-HH:MM
+- Work performed:
+  - Concrete outcome
+- Evidence:
+  - PR, commit, command result, file path, deployment link
+- Remaining:
+  - Next action or blocker
+- Suggested external worklog:
+  - Human-reviewed text for Jira or another system
+
+## Unassigned Work
+
+- Work that should be linked to an external ID later
+
+## Blockers
+
+- Task, blocker, owner, next checkpoint
+
+## Methodology Observations
+
+- Anything that made the awareness or worklog process better or worse
+```
+
+## Privacy Guardrails
+
+- Do not commit real worklogs, awareness boards, or memory files.
+- Do not store secrets, tokens, customer data, or private credentials in these files.
+- Do not use the awareness board as a long-term archive.
+- Prefer links or redacted evidence when a command output contains sensitive data.
+- Review generated end-of-day summaries before posting externally.

--- a/site/docs/agents/overview.md
+++ b/site/docs/agents/overview.md
@@ -54,6 +54,7 @@ See [REST API](/docs/api/rest-api) for endpoint reference.
 | **Deploy** | Static sites on `*.sites.fyso.dev`, custom domains (Pro), persistent deploy tokens for CI/CD |
 | **Integration** | Channels (custom MCP tools for bots), [web widget](./web-widget.md), bot identity system, publishable apps catalog, n8n community node |
 | **Memory** | [Agent memory](./agent-memory.md) — fact extraction and retrieval across conversations per end user |
+| **Agent operations** | [Agent Awareness Framework](./agent-awareness-framework.md) — methodology for private worklogs, live awareness, handoff, and self-improvement |
 | **Compliance** | [RGPD / GDPR](./rgpd-compliance.md) — DPA acceptance, session AI consent, data suppression, audit log |
 | **Testing** | [Test panel](./test-panel.md) — live chat with inspector modal (Flow, Steps, Summary, Raw) |
 


### PR DESCRIPTION
## Summary

Adds the Agent Awareness Framework as methodology documentation for humans working with multiple AI agents across parallel tasks.

This PR intentionally versions only the framework:

- operating principles and lifecycle
- private awareness/worklog templates
- evaluation and self-improvement loop
- overview link from the Agents section

It does not version real awareness boards, daily worklogs, personal memories, or local agent state.

## Evaluation loop

The self-improvement model is documented as:

1. observe friction from private awareness/worklog usage
2. score freshness, traceability, handoff quality, noise, and external reporting readiness
3. propose the smallest methodology change
4. review the change through a documentation PR

The framework explicitly avoids silent self-mutation and requires human review before methodology changes or external postings.

## Validation

- `npm run build`

Build completed successfully. Docusaurus reported existing broken-link and broken-anchor warnings from current site configuration/content, unrelated to these new pages.
